### PR TITLE
feat: add Dexie repositories

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import './App.css';
-import Formulario from './components/Formulario/Formulario';
 import Usuarios from './components/Usuarios';
 
 function App() {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,33 @@
+import Dexie, { Table } from 'dexie'
+import { System } from '@/models/System'
+import { DownPipe } from '@/models/DownPipe'
+import { Contribution } from '@/models/Contribution'
+import { Equipament } from '@/models/Equipament'
+import { EquipamentSet } from '@/models/EquipamentSet'
+import { Level } from '@/models/Level'
+import { Memorial } from '@/models/Memorial'
+
+export class AppDB extends Dexie {
+  systems!: Table<System, number>
+  downpipes!: Table<DownPipe, number>
+  contributions!: Table<Contribution, number>
+  equipaments!: Table<Equipament, number>
+  equipamentSets!: Table<EquipamentSet, number>
+  levels!: Table<Level, number>
+  memorials!: Table<Memorial, number>
+
+  constructor() {
+    super('fd-hidro')
+    this.version(1).stores({
+      systems: '++id, name, systemAbreviation, systemType',
+      downpipes: '++id, numeration, diameter, system',
+      contributions: '++id, level, equipament',
+      equipaments: '++id, name, abreviation, uhc',
+      equipamentSets: '++id, name',
+      levels: '++id, name, height',
+      memorials: '++id, name'
+    })
+  }
+}
+
+export const db = new AppDB()

--- a/src/repositories/BaseRepository.ts
+++ b/src/repositories/BaseRepository.ts
@@ -1,0 +1,25 @@
+import type { Table } from 'dexie'
+
+export class BaseRepository<T> {
+  constructor(private table: Table<T, number>) {}
+
+  async getAll(): Promise<T[]> {
+    return await this.table.toArray()
+  }
+
+  async getById(id: number): Promise<T | undefined> {
+    return await this.table.get(id)
+  }
+
+  async create(data: T): Promise<number> {
+    return await this.table.add(data)
+  }
+
+  async update(id: number, changes: Partial<T>): Promise<number> {
+    return await this.table.update(id, changes)
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.table.delete(id)
+  }
+}

--- a/src/repositories/ContributionRepository.ts
+++ b/src/repositories/ContributionRepository.ts
@@ -1,0 +1,11 @@
+import { db } from '@/db'
+import type { Contribution } from '@/models/Contribution'
+import { BaseRepository } from './BaseRepository'
+
+class ContributionRepository extends BaseRepository<Contribution> {
+  constructor() {
+    super(db.contributions)
+  }
+}
+
+export default new ContributionRepository()

--- a/src/repositories/DownPipeRepository.ts
+++ b/src/repositories/DownPipeRepository.ts
@@ -1,0 +1,11 @@
+import { db } from '@/db'
+import type { DownPipe } from '@/models/DownPipe'
+import { BaseRepository } from './BaseRepository'
+
+class DownPipeRepository extends BaseRepository<DownPipe> {
+  constructor() {
+    super(db.downpipes)
+  }
+}
+
+export default new DownPipeRepository()

--- a/src/repositories/EquipamentRepository.ts
+++ b/src/repositories/EquipamentRepository.ts
@@ -1,0 +1,11 @@
+import { db } from '@/db'
+import type { Equipament } from '@/models/Equipament'
+import { BaseRepository } from './BaseRepository'
+
+class EquipamentRepository extends BaseRepository<Equipament> {
+  constructor() {
+    super(db.equipaments)
+  }
+}
+
+export default new EquipamentRepository()

--- a/src/repositories/EquipamentSetRepository.ts
+++ b/src/repositories/EquipamentSetRepository.ts
@@ -1,0 +1,11 @@
+import { db } from '@/db'
+import type { EquipamentSet } from '@/models/EquipamentSet'
+import { BaseRepository } from './BaseRepository'
+
+class EquipamentSetRepository extends BaseRepository<EquipamentSet> {
+  constructor() {
+    super(db.equipamentSets)
+  }
+}
+
+export default new EquipamentSetRepository()

--- a/src/repositories/LevelRepository.ts
+++ b/src/repositories/LevelRepository.ts
@@ -1,0 +1,11 @@
+import { db } from '@/db'
+import type { Level } from '@/models/Level'
+import { BaseRepository } from './BaseRepository'
+
+class LevelRepository extends BaseRepository<Level> {
+  constructor() {
+    super(db.levels)
+  }
+}
+
+export default new LevelRepository()

--- a/src/repositories/MemorialRepository.ts
+++ b/src/repositories/MemorialRepository.ts
@@ -1,0 +1,11 @@
+import { db } from '@/db'
+import type { Memorial } from '@/models/Memorial'
+import { BaseRepository } from './BaseRepository'
+
+class MemorialRepository extends BaseRepository<Memorial> {
+  constructor() {
+    super(db.memorials)
+  }
+}
+
+export default new MemorialRepository()

--- a/src/repositories/SystemRepository.ts
+++ b/src/repositories/SystemRepository.ts
@@ -1,0 +1,11 @@
+import { db } from '@/db'
+import type { System } from '@/models/System'
+import { BaseRepository } from './BaseRepository'
+
+class SystemRepository extends BaseRepository<System> {
+  constructor() {
+    super(db.systems)
+  }
+}
+
+export default new SystemRepository()


### PR DESCRIPTION
## Summary
- add Dexie database instance and generic base repository
- implement async CRUD repositories for each entity
- remove unused import from App

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893d8b310ac8321819ec24778f4a0da