### PR TITLE
refactor: derive table columns

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,34 +1,37 @@
-type genericObject = {
-    id: number;
-    [key: string]: string | number;
-}
-
 interface TableProps {
-    data: genericObject[];
-    columns: {
-        id: string;
-        name: string;
-    }[];
+    data: Record<string, unknown>[];
 }
 
-const Table = ({ data, columns }: TableProps) => {
+const Table = ({ data }: TableProps) => {
+    const columns = Object.keys(data[0] ?? {}).filter((key) => {
+        const value = data[0]?.[key];
+        return key !== "id" && (typeof value === "string" || typeof value === "number");
+    });
+
     return (
         <table className="table-auto w-full">
             <thead>
                 <tr>
                     {columns.map((column) => (
-                        <th key={column.id} className="border border-stone-300 p-2">{column.name}</th>
+                        <th key={column} className="border border-stone-300 p-2">{column}</th>
                     ))}
                 </tr>
             </thead>
             <tbody>
-                {data.map((row) => (
-                    <tr key={row.id}>
-                        {columns.map((column) => (
-                            <td key={column.id} className="border border-stone-300 p-2">{row[column.id]}</td>
-                        ))}
-                    </tr>
-                ))}
+                {data.map((row, index) => {
+                    const rowId = row["id"];
+                    const key = typeof rowId === "string" || typeof rowId === "number" ? rowId : index;
+
+                    return (
+                        <tr key={key}>
+                            {columns.map((column) => (
+                                <td key={column} className="border border-stone-300 p-2">
+                                    {row[column] as string | number}
+                                </td>
+                            ))}
+                        </tr>
+                    );
+                })}
             </tbody>
         </table>
     );


### PR DESCRIPTION
## Summary
- derive table columns from data and render generically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: src/repositories/BaseRepository.ts:19:40 - No overload matches this call)*

------
https://chatgpt.com/codex/tasks/task_e_6893e32dd1d48321b6d5d541bd551be9