### PR TITLE
Display equipment table in editor page

### DIFF
--- a/src/pages/EquipamentsEditor/index.tsx
+++ b/src/pages/EquipamentsEditor/index.tsx
@@ -1,10 +1,23 @@
+import { useEffect, useState } from 'react';
 import { Toaster } from 'sonner';
+import type { Equipament } from '@/models/Equipament';
+import EquipamentRepository from '@/repositories/EquipamentRepository';
+import Table from '@/components/Table/Table';
 
 export default function EquipamentsEditor() {
+	const [equipaments, setEquipaments] = useState<Equipament[]>([]);
+	
+	useEffect(() => {
+		EquipamentRepository.getAll().then(setEquipaments);
+	}, []);
+	
 	return (
 		<section className="container mx-auto pb-4">
-			<Toaster />
-			<h1 className="my-4">Menu de Edição de Peças Hidráulicas</h1>
+		<Toaster />
+		<h1 className="my-4">Menu de Edição de Peças Hidráulicas</h1>
+		<Table data={equipaments} />
 		</section>
-	)
+	);
 }
+
+


### PR DESCRIPTION
## Summary
- load equipments from repository and show in table

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893e4a25c5c8321ab4466d0a4f7bb0c