### PR TITLE
Add table row serialization to models

### DIFF
--- a/src/models/Contribution.ts
+++ b/src/models/Contribution.ts
@@ -14,5 +14,18 @@ export class Contribution {
       ? this.equipament.totaluhc
       : this.equipament.uhc;
   }
+
+  toTableRow(): Record<string, string | number> {
+    return {
+      ID: this.id,
+      Nível: this.level.name,
+      Equipamento: this.equipament.name,
+      UHC: this.totaluhc,
+    };
+  }
+
+  static tableColumns(): string[] {
+    return ['ID', 'Nível', 'Equipamento', 'UHC'];
+  }
 }
 

--- a/src/models/DownPipe.ts
+++ b/src/models/DownPipe.ts
@@ -14,14 +14,14 @@ export class DownPipe {
     return this.contributions.reduce((sum, c) => sum + c.totaluhc, 0);
   }
 
-  get abreviation(): string {
+  get name(): string {
     return `${this.system.systemAbreviation}${this.numeration}`;
   }
 
   toTableRow(): Record<string, string | number> {
     return {
       ID: this.id,
-      Numeração: this.numeration,
+      Nome: this.name,
       Diâmetro: this.diameter,
       Sistema: this.system.name,
       'UHC Total': this.totaluhc,
@@ -29,7 +29,7 @@ export class DownPipe {
   }
 
   static tableColumns(): string[] {
-    return ['ID', 'Numeração', 'Diâmetro', 'Sistema', 'UHC Total'];
+    return ['ID', 'Nome', 'Diâmetro', 'Sistema', 'UHC Total'];
   }
 }
 

--- a/src/models/DownPipe.ts
+++ b/src/models/DownPipe.ts
@@ -17,5 +17,19 @@ export class DownPipe {
   get abreviation(): string {
     return `${this.system.systemAbreviation}${this.numeration}`;
   }
+
+  toTableRow(): Record<string, string | number> {
+    return {
+      ID: this.id,
+      Numeração: this.numeration,
+      Diâmetro: this.diameter,
+      Sistema: this.system.name,
+      'UHC Total': this.totaluhc,
+    };
+  }
+
+  static tableColumns(): string[] {
+    return ['ID', 'Numeração', 'Diâmetro', 'Sistema', 'UHC Total'];
+  }
 }
 

--- a/src/models/Equipament.ts
+++ b/src/models/Equipament.ts
@@ -5,5 +5,18 @@ export class Equipament {
     public abreviation: string,
     public uhc: number
   ) {}
+
+  toTableRow(): Record<string, string | number> {
+    return {
+      ID: this.id,
+      Nome: this.name,
+      Abreviação: this.abreviation,
+      UHC: this.uhc,
+    };
+  }
+
+  static tableColumns(): string[] {
+    return ['ID', 'Nome', 'Abreviação', 'UHC'];
+  }
 }
 

--- a/src/models/EquipamentSet.ts
+++ b/src/models/EquipamentSet.ts
@@ -15,5 +15,17 @@ export class EquipamentSet {
       return sum + item.uhc;
     }, 0);
   }
+
+  toTableRow(): Record<string, string | number> {
+    return {
+      ID: this.id,
+      Nome: this.name,
+      'UHC Total': this.totaluhc,
+    };
+  }
+
+  static tableColumns(): string[] {
+    return ['ID', 'Nome', 'UHC Total'];
+  }
 }
 

--- a/src/models/Level.ts
+++ b/src/models/Level.ts
@@ -4,5 +4,17 @@ export class Level {
     public name: string,
     public height: number
   ) {}
+
+  toTableRow(): Record<string, string | number> {
+    return {
+      ID: this.id,
+      Nome: this.name,
+      Altura: this.height,
+    };
+  }
+
+  static tableColumns(): string[] {
+    return ['ID', 'Nome', 'Altura'];
+  }
 }
 

--- a/src/models/Memorial.ts
+++ b/src/models/Memorial.ts
@@ -6,5 +6,16 @@ export class Memorial {
     public name: string,
     public downpipes: DownPipe[] = []
   ) {}
+
+  toTableRow(): Record<string, string | number> {
+    return {
+      ID: this.id,
+      Nome: this.name,
+    };
+  }
+
+  static tableColumns(): string[] {
+    return ['ID', 'Nome'];
+  }
 }
 

--- a/src/models/System.ts
+++ b/src/models/System.ts
@@ -7,5 +7,18 @@ export class System {
     public systemAbreviation: string,
     public systemType: SystemType
   ) {}
+
+  toTableRow(): Record<string, string | number> {
+    return {
+      ID: this.id,
+      Nome: this.name,
+      Abreviação: this.systemAbreviation,
+      Tipo: this.systemType,
+    };
+  }
+
+  static tableColumns(): string[] {
+    return ['ID', 'Nome', 'Abreviação', 'Tipo'];
+  }
 }
 


### PR DESCRIPTION
## Summary
- add `toTableRow` to Level, Equipment and other domain models
- expose static `tableColumns` for consistent table headers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: TS2322: Type 'Equipament[]' is not assignable to type 'Record<string, unknown>[]')*

------
https://chatgpt.com/codex/tasks/task_e_6893ed609a508321be86e487811ef0c0