### PR TITLE
Use IDs for contributions and add hydration utility

### DIFF
--- a/src/models/Contribution.ts
+++ b/src/models/Contribution.ts
@@ -1,9 +1,18 @@
+import type { IElement } from './InterfaceElement';
 import { Level } from './Level';
 import { Equipament } from './Equipament';
 import { EquipamentSet } from './EquipamentSet';
-import type { IElement } from './InterfaceElement';
 
-export class Contribution implements IElement {
+export class Contribution {
+  constructor(
+    public id: number,
+    public levelId: number,
+    public equipamentId?: number,
+    public equipamentSetId?: number
+  ) {}
+}
+
+export class HydratedContribution implements IElement {
   constructor(
     public id: number,
     public level: Level,
@@ -25,4 +34,3 @@ export class Contribution implements IElement {
     };
   }
 }
-

--- a/src/models/DownPipe.ts
+++ b/src/models/DownPipe.ts
@@ -1,4 +1,4 @@
-import { Contribution } from './Contribution';
+import type { HydratedContribution } from './Contribution';
 import type { System } from './System';
 import type { IElement } from './InterfaceElement';
 
@@ -8,7 +8,7 @@ export class DownPipe implements IElement {
     public numeration: string,
     public diameter: number,
     public system: System,
-    public contributions: Contribution[] = []
+    public contributions: HydratedContribution[] = []
   ) {}
 
   get totaluhc(): number {

--- a/src/repositories/ContributionRepository.ts
+++ b/src/repositories/ContributionRepository.ts
@@ -1,10 +1,21 @@
 import { db } from '@/db/db'
-import type { Contribution } from '@/models/Contribution'
+import type { Contribution, HydratedContribution } from '@/models/Contribution'
 import { BaseRepository } from './BaseRepository'
+import { hydrateContribution } from '@/utils/hydrateContribution'
 
 class ContributionRepository extends BaseRepository<Contribution> {
   constructor() {
     super(db.contributions)
+  }
+
+  async getAllHydrated(): Promise<HydratedContribution[]> {
+    const records = await this.getAll()
+    return Promise.all(records.map(hydrateContribution))
+  }
+
+  async getHydratedById(id: number): Promise<HydratedContribution | undefined> {
+    const record = await this.getById(id)
+    return record ? await hydrateContribution(record) : undefined
   }
 }
 

--- a/src/seeds/contributions.ts
+++ b/src/seeds/contributions.ts
@@ -2,27 +2,20 @@ import type { AppDB } from '@/db/db';
 import { Contribution } from '@/models/Contribution';
 
 export async function seedContributions(db: AppDB) {
-  const levels = await db.levels.toArray();
-  const equipaments = await db.equipaments.toArray();
-  const sets = await db.equipamentSets.toArray();
-  const l = (id: number) => levels.find(level => level.id === id)!;
-  const e = (id: number) => equipaments.find(eq => eq.id === id)!;
-  const s = (id: number) => sets.find(set => set.id === id)!;
-
   const contributions: Contribution[] = [
-    new Contribution(1, l(1), e(1)),
-    new Contribution(2, l(1), s(1)),
-    new Contribution(3, l(2), e(2)),
-    new Contribution(4, l(2), s(2)),
-    new Contribution(5, l(3), e(3)),
-    new Contribution(6, l(3), s(3)),
-    new Contribution(7, l(4), e(4)),
-    new Contribution(8, l(4), e(5)),
-    new Contribution(9, l(5), e(7)),
-    new Contribution(10, l(5), e(9)),
-    new Contribution(11, l(6), e(10)),
-    new Contribution(12, l(6), e(8)),
+    new Contribution(1, 1, 1),
+    new Contribution(2, 1, undefined, 1),
+    new Contribution(3, 2, 2),
+    new Contribution(4, 2, undefined, 2),
+    new Contribution(5, 3, 3),
+    new Contribution(6, 3, undefined, 3),
+    new Contribution(7, 4, 4),
+    new Contribution(8, 4, 5),
+    new Contribution(9, 5, 7),
+    new Contribution(10, 5, 9),
+    new Contribution(11, 6, 10),
+    new Contribution(12, 6, 8),
   ];
-  
+
   await db.contributions.bulkAdd(contributions);
 }

--- a/src/seeds/downPipes.ts
+++ b/src/seeds/downPipes.ts
@@ -1,21 +1,79 @@
 import type { AppDB } from '@/db/db';
 import { DownPipe } from '@/models/DownPipe';
+import { hydrateContribution } from '@/utils/hydrateContribution';
 
 export async function seedDownPipes(db: AppDB) {
   const systems = await db.systems.toArray();
   const contributions = await db.contributions.toArray();
   const s = (id: number) => systems.find(sys => sys.id === id)!;
-  const c = (id: number) => contributions.find(con => con.id === id)!;
+  const c = async (id: number) =>
+    hydrateContribution(contributions.find(con => con.id === id)!);
 
   const downpipes: DownPipe[] = [
-    new DownPipe(1, '1', 100, s(1), [c(1), c(3), c(5), c(7), c(9), c(11)]),
-    new DownPipe(2, '2', 100, s(1), [c(2), c(4), c(6), c(8), c(10), c(12)]),
-    new DownPipe(3, '1', 100, s(2), [c(1), c(4), c(5), c(8), c(9), c(11)]),
-    new DownPipe(4, '2', 100, s(2), [c(2), c(3), c(6), c(7), c(10), c(12)]),
-    new DownPipe(5, '1', 100, s(3), [c(1), c(4), c(6), c(7), c(9), c(11)]),
-    new DownPipe(6, '2', 100, s(3), [c(2), c(3), c(5), c(8), c(10), c(12)]),
-    new DownPipe(7, '1', 100, s(4), [c(1), c(3), c(5), c(7), c(10), c(11)]),
-    new DownPipe(8, '2', 100, s(4), [c(2), c(4), c(6), c(8), c(9), c(12)]),
+    new DownPipe(1, '1', 100, s(1), [
+      await c(1),
+      await c(3),
+      await c(5),
+      await c(7),
+      await c(9),
+      await c(11),
+    ]),
+    new DownPipe(2, '2', 100, s(1), [
+      await c(2),
+      await c(4),
+      await c(6),
+      await c(8),
+      await c(10),
+      await c(12),
+    ]),
+    new DownPipe(3, '1', 100, s(2), [
+      await c(1),
+      await c(4),
+      await c(5),
+      await c(8),
+      await c(9),
+      await c(11),
+    ]),
+    new DownPipe(4, '2', 100, s(2), [
+      await c(2),
+      await c(3),
+      await c(6),
+      await c(7),
+      await c(10),
+      await c(12),
+    ]),
+    new DownPipe(5, '1', 100, s(3), [
+      await c(1),
+      await c(4),
+      await c(6),
+      await c(7),
+      await c(9),
+      await c(11),
+    ]),
+    new DownPipe(6, '2', 100, s(3), [
+      await c(2),
+      await c(3),
+      await c(5),
+      await c(8),
+      await c(10),
+      await c(12),
+    ]),
+    new DownPipe(7, '1', 100, s(4), [
+      await c(1),
+      await c(3),
+      await c(5),
+      await c(7),
+      await c(10),
+      await c(11),
+    ]),
+    new DownPipe(8, '2', 100, s(4), [
+      await c(2),
+      await c(4),
+      await c(6),
+      await c(8),
+      await c(9),
+      await c(12),
+    ]),
   ];
 
   await db.downpipes.bulkAdd(downpipes);

--- a/src/utils/hydrateContribution.ts
+++ b/src/utils/hydrateContribution.ts
@@ -1,0 +1,27 @@
+import { Contribution, HydratedContribution } from '@/models/Contribution';
+import LevelRepository from '@/repositories/LevelRepository';
+import EquipamentRepository from '@/repositories/EquipamentRepository';
+import EquipamentSetRepository from '@/repositories/EquipamentSetRepository';
+
+export async function hydrateContribution(
+  contribution: Contribution
+): Promise<HydratedContribution> {
+  const level = await LevelRepository.getById(contribution.levelId);
+  if (!level) {
+    throw new Error(`Level ${contribution.levelId} not found`);
+  }
+
+  const equipament =
+    contribution.equipamentId !== undefined
+      ? await EquipamentRepository.getById(contribution.equipamentId)
+      : await EquipamentSetRepository.getById(contribution.equipamentSetId!);
+  if (!equipament) {
+    throw new Error(
+      `Equipament ${
+        contribution.equipamentId ?? contribution.equipamentSetId
+      } not found`
+    );
+  }
+
+  return new HydratedContribution(contribution.id, level, equipament);
+}


### PR DESCRIPTION
## Summary
- store relations in contributions as IDs and add hydrated representation
- add hydrateContribution helper and hydrated fetch methods in repository
- update seeds and downpipe model to work with new ID-based structure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: TS2769 in BaseRepository.update)*

------
https://chatgpt.com/codex/tasks/task_e_68968ba3fb14832196bc582a03eb0daf