### PR TITLE
refactor: use DTO mapping for data stores

### DIFF
--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -1,20 +1,20 @@
 import Dexie, { type Table } from 'dexie';
-import { System } from '@/models/System';
-import { Level } from '@/models/Level';
-import { Equipament } from '@/models/Equipament';
-import { EquipamentSet } from '@/models/EquipamentSet';
-import { Contribution } from '@/models/Contribution';
-import { DownPipe } from '@/models/DownPipe';
-import { Memorial } from '@/models/Memorial';
+import type { SystemDTO } from '@/dto/system';
+import type { LevelDTO } from '@/dto/level';
+import type { EquipamentDTO } from '@/dto/equipament';
+import type { EquipamentSetDTO } from '@/dto/equipamentSet';
+import type { ContributionDTO } from '@/dto/contribution';
+import type { DownPipeDTO } from '@/dto/downPipe';
+import type { MemorialDTO } from '@/dto/memorial';
 
 export class AppDB extends Dexie {
-  systems!: Table<System, number>;
-  levels!: Table<Level, number>;
-  equipaments!: Table<Equipament, number>;
-  equipamentSets!: Table<EquipamentSet, number>;
-  contributions!: Table<Contribution, number>;
-  downpipes!: Table<DownPipe, number>;
-  memorials!: Table<Memorial, number>;
+  systems!: Table<SystemDTO, number>;
+  levels!: Table<LevelDTO, number>;
+  equipaments!: Table<EquipamentDTO, number>;
+  equipamentSets!: Table<EquipamentSetDTO, number>;
+  contributions!: Table<ContributionDTO, number>;
+  downpipes!: Table<DownPipeDTO, number>;
+  memorials!: Table<MemorialDTO, number>;
 
   constructor() {
     super('fd-hidro');
@@ -28,13 +28,6 @@ export class AppDB extends Dexie {
       memorials: '++id',
     });
 
-    this.systems.mapToClass(System);
-    this.levels.mapToClass(Level);
-    this.equipaments.mapToClass(Equipament);
-    this.equipamentSets.mapToClass(EquipamentSet);
-    this.contributions.mapToClass(Contribution);
-    this.downpipes.mapToClass(DownPipe);
-    this.memorials.mapToClass(Memorial);
   }
 }
 

--- a/src/dto/contribution.ts
+++ b/src/dto/contribution.ts
@@ -1,0 +1,67 @@
+export interface ContributionDTO {
+  id?: number;
+  levelId: number;
+  equipamentId?: number;
+  equipamentSetId?: number;
+}
+
+import { Contribution, HydratedContribution } from '@/models/Contribution';
+import { Level } from '@/models/Level';
+import { Equipament } from '@/models/Equipament';
+import { EquipamentSet } from '@/models/EquipamentSet';
+import { toLevel, fromLevel, type LevelDTO } from './level';
+import { toEquipament, fromEquipament, type EquipamentDTO } from './equipament';
+import {
+  toEquipamentSet,
+  fromEquipamentSet,
+  type EquipamentSetDTO,
+} from './equipamentSet';
+
+export function toContribution(dto: ContributionDTO): Contribution {
+  return new Contribution(
+    dto.id ?? 0,
+    dto.levelId,
+    dto.equipamentId,
+    dto.equipamentSetId,
+  );
+}
+
+export function fromContribution(model: Contribution): ContributionDTO {
+  return {
+    id: model.id,
+    levelId: model.levelId,
+    equipamentId: model.equipamentId,
+    equipamentSetId: model.equipamentSetId,
+  };
+}
+
+export interface HydratedContributionDTO {
+  id: number;
+  level: LevelDTO;
+  equipament: EquipamentDTO | EquipamentSetDTO;
+}
+
+export function toHydratedContribution(
+  dto: HydratedContributionDTO,
+): HydratedContribution {
+  const level: Level = toLevel(dto.level);
+  const equipament: Equipament | EquipamentSet =
+    'equipaments' in dto.equipament
+      ? toEquipamentSet(dto.equipament as EquipamentSetDTO)
+      : toEquipament(dto.equipament as EquipamentDTO);
+  return new HydratedContribution(dto.id, level, equipament);
+}
+
+export function fromHydratedContribution(
+  model: HydratedContribution,
+): HydratedContributionDTO {
+  const equipament =
+    model.equipament instanceof EquipamentSet
+      ? fromEquipamentSet(model.equipament)
+      : fromEquipament(model.equipament as Equipament);
+  return {
+    id: model.id,
+    level: fromLevel(model.level),
+    equipament,
+  };
+}

--- a/src/dto/downPipe.ts
+++ b/src/dto/downPipe.ts
@@ -1,0 +1,31 @@
+import { DownPipe } from '@/models/DownPipe';
+import { toSystem, fromSystem, type SystemDTO } from './system';
+import {
+  toHydratedContribution,
+  fromHydratedContribution,
+  type HydratedContributionDTO,
+} from './contribution';
+
+export interface DownPipeDTO {
+  id?: number;
+  numeration: string;
+  diameter: number;
+  system: SystemDTO;
+  contributions: HydratedContributionDTO[];
+}
+
+export function toDownPipe(dto: DownPipeDTO): DownPipe {
+  const system = toSystem(dto.system);
+  const contributions = dto.contributions.map(toHydratedContribution);
+  return new DownPipe(dto.id ?? 0, dto.numeration, dto.diameter, system, contributions);
+}
+
+export function fromDownPipe(model: DownPipe): DownPipeDTO {
+  return {
+    id: model.id,
+    numeration: model.numeration,
+    diameter: model.diameter,
+    system: fromSystem(model.system),
+    contributions: model.contributions.map(fromHydratedContribution),
+  };
+}

--- a/src/dto/equipament.ts
+++ b/src/dto/equipament.ts
@@ -1,0 +1,21 @@
+import { Equipament } from '@/models/Equipament';
+
+export interface EquipamentDTO {
+  id?: number;
+  name: string;
+  abreviation: string;
+  uhc: number;
+}
+
+export function toEquipament(dto: EquipamentDTO): Equipament {
+  return new Equipament(dto.id, dto.name, dto.abreviation, dto.uhc);
+}
+
+export function fromEquipament(model: Equipament): EquipamentDTO {
+  return {
+    id: model.id,
+    name: model.name,
+    abreviation: model.abreviation,
+    uhc: model.uhc,
+  };
+}

--- a/src/dto/equipamentSet.ts
+++ b/src/dto/equipamentSet.ts
@@ -1,0 +1,27 @@
+import { EquipamentSet } from '@/models/EquipamentSet';
+import { Equipament } from '@/models/Equipament';
+import { toEquipament, fromEquipament, type EquipamentDTO } from './equipament';
+
+export interface EquipamentSetDTO {
+  id?: number;
+  name: string;
+  equipaments: Array<EquipamentDTO | EquipamentSetDTO>;
+}
+
+export function toEquipamentSet(dto: EquipamentSetDTO): EquipamentSet {
+  const equipaments = dto.equipaments.map(item =>
+    'equipaments' in item
+      ? toEquipamentSet(item as EquipamentSetDTO)
+      : toEquipament(item as EquipamentDTO)
+  );
+  return new EquipamentSet(dto.id ?? 0, dto.name, equipaments);
+}
+
+export function fromEquipamentSet(model: EquipamentSet): EquipamentSetDTO {
+  const equipaments = model.equipaments.map(item =>
+    item instanceof EquipamentSet
+      ? fromEquipamentSet(item)
+      : fromEquipament(item as Equipament)
+  );
+  return { id: model.id, name: model.name, equipaments };
+}

--- a/src/dto/level.ts
+++ b/src/dto/level.ts
@@ -1,0 +1,19 @@
+import { Level } from '@/models/Level';
+
+export interface LevelDTO {
+  id?: number;
+  name: string;
+  height: number;
+}
+
+export function toLevel(dto: LevelDTO): Level {
+  return new Level(dto.id ?? 0, dto.name, dto.height);
+}
+
+export function fromLevel(model: Level): LevelDTO {
+  return {
+    id: model.id,
+    name: model.name,
+    height: model.height,
+  };
+}

--- a/src/dto/memorial.ts
+++ b/src/dto/memorial.ts
@@ -1,0 +1,21 @@
+import { Memorial } from '@/models/Memorial';
+import { toDownPipe, fromDownPipe, type DownPipeDTO } from './downPipe';
+
+export interface MemorialDTO {
+  id?: number;
+  name: string;
+  downpipes: DownPipeDTO[];
+}
+
+export function toMemorial(dto: MemorialDTO): Memorial {
+  const downpipes = dto.downpipes.map(toDownPipe);
+  return new Memorial(dto.id ?? 0, dto.name, downpipes);
+}
+
+export function fromMemorial(model: Memorial): MemorialDTO {
+  return {
+    id: model.id,
+    name: model.name,
+    downpipes: model.downpipes.map(fromDownPipe),
+  };
+}

--- a/src/dto/system.ts
+++ b/src/dto/system.ts
@@ -1,0 +1,22 @@
+import { System } from '@/models/System';
+import { SystemType } from '@/models/enums/SystemType';
+
+export interface SystemDTO {
+  id?: number;
+  name: string;
+  systemAbreviation: string;
+  systemType: SystemType;
+}
+
+export function toSystem(dto: SystemDTO): System {
+  return new System(dto.id ?? 0, dto.name, dto.systemAbreviation, dto.systemType);
+}
+
+export function fromSystem(model: System): SystemDTO {
+  return {
+    id: model.id,
+    name: model.name,
+    systemAbreviation: model.systemAbreviation,
+    systemType: model.systemType,
+  };
+}

--- a/src/repositories/ContributionRepository.ts
+++ b/src/repositories/ContributionRepository.ts
@@ -1,22 +1,46 @@
-import { db } from '@/db/db'
-import type { Contribution, HydratedContribution } from '@/models/Contribution'
-import { BaseRepository } from './BaseRepository'
-import { hydrateContribution } from '@/utils/hydrateContribution'
+import { db } from '@/db/db';
+import { Contribution } from '@/models/Contribution';
+import type { HydratedContribution } from '@/models/Contribution';
+import { hydrateContribution } from '@/utils/hydrateContribution';
+import { fromContribution, toContribution, type ContributionDTO } from '@/dto/contribution';
 
-class ContributionRepository extends BaseRepository<Contribution> {
-  constructor() {
-    super(db.contributions)
+class ContributionRepository {
+  private table = db.contributions;
+
+  async getAll(): Promise<Contribution[]> {
+    const records = await this.table.toArray();
+    return records.map(toContribution);
+  }
+
+  async getById(id: number): Promise<Contribution | undefined> {
+    const record = await this.table.get(id);
+    return record ? toContribution(record) : undefined;
+  }
+
+  async create(data: Contribution): Promise<Contribution> {
+    const dto: ContributionDTO = fromContribution(data);
+    const id = await this.table.add(dto);
+    return new Contribution(id, data.levelId, data.equipamentId, data.equipamentSetId);
+  }
+
+  async update(id: number, changes: Partial<Contribution>): Promise<number> {
+    const dtoChanges: Partial<ContributionDTO> = { ...changes };
+    return await this.table.update(id, dtoChanges);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.table.delete(id);
   }
 
   async getAllHydrated(): Promise<HydratedContribution[]> {
-    const records = await this.getAll()
-    return Promise.all(records.map(hydrateContribution))
+    const records = await this.getAll();
+    return Promise.all(records.map(hydrateContribution));
   }
 
   async getHydratedById(id: number): Promise<HydratedContribution | undefined> {
-    const record = await this.getById(id)
-    return record ? await hydrateContribution(record) : undefined
+    const record = await this.getById(id);
+    return record ? await hydrateContribution(record) : undefined;
   }
 }
 
-export default new ContributionRepository()
+export default new ContributionRepository();

--- a/src/repositories/DownPipeRepository.ts
+++ b/src/repositories/DownPipeRepository.ts
@@ -1,10 +1,11 @@
 import { db } from '@/db/db'
 import type { DownPipe } from '@/models/DownPipe'
 import { BaseRepository } from './BaseRepository'
+import { toDownPipe, fromDownPipe, type DownPipeDTO } from '@/dto/downPipe'
 
-class DownPipeRepository extends BaseRepository<DownPipe> {
+class DownPipeRepository extends BaseRepository<DownPipe, DownPipeDTO> {
   constructor() {
-    super(db.downpipes)
+    super(db.downpipes, toDownPipe, fromDownPipe)
   }
 }
 

--- a/src/repositories/EquipamentRepository.ts
+++ b/src/repositories/EquipamentRepository.ts
@@ -1,10 +1,11 @@
 import { db } from '@/db/db'
 import type { Equipament } from '@/models/Equipament'
 import { BaseRepository } from './BaseRepository'
+import { toEquipament, fromEquipament, type EquipamentDTO } from '@/dto/equipament'
 
-class EquipamentRepository extends BaseRepository<Equipament> {
+class EquipamentRepository extends BaseRepository<Equipament, EquipamentDTO> {
   constructor() {
-    super(db.equipaments)
+    super(db.equipaments, toEquipament, fromEquipament)
   }
 }
 

--- a/src/repositories/EquipamentSetRepository.ts
+++ b/src/repositories/EquipamentSetRepository.ts
@@ -1,10 +1,15 @@
 import { db } from '@/db/db'
 import type { EquipamentSet } from '@/models/EquipamentSet'
 import { BaseRepository } from './BaseRepository'
+import {
+  toEquipamentSet,
+  fromEquipamentSet,
+  type EquipamentSetDTO,
+} from '@/dto/equipamentSet'
 
-class EquipamentSetRepository extends BaseRepository<EquipamentSet> {
+class EquipamentSetRepository extends BaseRepository<EquipamentSet, EquipamentSetDTO> {
   constructor() {
-    super(db.equipamentSets)
+    super(db.equipamentSets, toEquipamentSet, fromEquipamentSet)
   }
 }
 

--- a/src/repositories/LevelRepository.ts
+++ b/src/repositories/LevelRepository.ts
@@ -1,10 +1,11 @@
 import { db } from '@/db/db'
 import type { Level } from '@/models/Level'
 import { BaseRepository } from './BaseRepository'
+import { toLevel, fromLevel, type LevelDTO } from '@/dto/level'
 
-class LevelRepository extends BaseRepository<Level> {
+class LevelRepository extends BaseRepository<Level, LevelDTO> {
   constructor() {
-    super(db.levels)
+    super(db.levels, toLevel, fromLevel)
   }
 }
 

--- a/src/repositories/MemorialRepository.ts
+++ b/src/repositories/MemorialRepository.ts
@@ -1,10 +1,11 @@
 import { db } from '@/db/db'
 import type { Memorial } from '@/models/Memorial'
 import { BaseRepository } from './BaseRepository'
+import { toMemorial, fromMemorial, type MemorialDTO } from '@/dto/memorial'
 
-class MemorialRepository extends BaseRepository<Memorial> {
+class MemorialRepository extends BaseRepository<Memorial, MemorialDTO> {
   constructor() {
-    super(db.memorials)
+    super(db.memorials, toMemorial, fromMemorial)
   }
 }
 

--- a/src/repositories/SystemRepository.ts
+++ b/src/repositories/SystemRepository.ts
@@ -1,10 +1,11 @@
 import { db } from '@/db/db'
 import type { System } from '@/models/System'
 import { BaseRepository } from './BaseRepository'
+import { toSystem, fromSystem, type SystemDTO } from '@/dto/system'
 
-class SystemRepository extends BaseRepository<System> {
+class SystemRepository extends BaseRepository<System, SystemDTO> {
   constructor() {
-    super(db.systems)
+    super(db.systems, toSystem, fromSystem)
   }
 }
 

--- a/src/seeds/contributions.ts
+++ b/src/seeds/contributions.ts
@@ -1,5 +1,6 @@
 import type { AppDB } from '@/db/db';
 import { Contribution } from '@/models/Contribution';
+import { fromContribution } from '@/dto/contribution';
 
 export async function seedContributions(db: AppDB) {
   const contributions: Contribution[] = [
@@ -17,5 +18,5 @@ export async function seedContributions(db: AppDB) {
     new Contribution(12, 6, 8),
   ];
 
-  await db.contributions.bulkAdd(contributions);
+  await db.contributions.bulkAdd(contributions.map(fromContribution));
 }

--- a/src/seeds/downPipes.ts
+++ b/src/seeds/downPipes.ts
@@ -1,10 +1,13 @@
 import type { AppDB } from '@/db/db';
 import { DownPipe } from '@/models/DownPipe';
 import { hydrateContribution } from '@/utils/hydrateContribution';
+import { toContribution } from '@/dto/contribution';
+import { toSystem } from '@/dto/system';
+import { fromDownPipe as fromDownPipeDTO } from '@/dto/downPipe';
 
 export async function seedDownPipes(db: AppDB) {
-  const systems = await db.systems.toArray();
-  const contributions = await db.contributions.toArray();
+  const systems = (await db.systems.toArray()).map(toSystem);
+  const contributions = (await db.contributions.toArray()).map(toContribution);
   const s = (id: number) => systems.find(sys => sys.id === id)!;
   const c = async (id: number) =>
     hydrateContribution(contributions.find(con => con.id === id)!);
@@ -76,5 +79,5 @@ export async function seedDownPipes(db: AppDB) {
     ]),
   ];
 
-  await db.downpipes.bulkAdd(downpipes);
+  await db.downpipes.bulkAdd(downpipes.map(fromDownPipeDTO));
 }

--- a/src/seeds/equipamentSets.ts
+++ b/src/seeds/equipamentSets.ts
@@ -1,8 +1,10 @@
 import type { AppDB } from '@/db/db';
 import { EquipamentSet } from '@/models/EquipamentSet';
+import { toEquipament } from '@/dto/equipament';
+import { fromEquipamentSet } from '@/dto/equipamentSet';
 
 export async function seedEquipamentSets(db: AppDB) {
-  const equipaments = await db.equipaments.toArray();
+  const equipaments = (await db.equipaments.toArray()).map(toEquipament);
   const e = (id: number) => equipaments.find(eq => eq.id === id)!;
 
   const sets: EquipamentSet[] = [
@@ -10,5 +12,5 @@ export async function seedEquipamentSets(db: AppDB) {
     new EquipamentSet(2, 'Lavabo', [e(1), e(2), e(4)]),
     new EquipamentSet(3, 'Área de Serviço e Cozinha', [e(7), e(10), e(9)]),
   ];
-  await db.equipamentSets.bulkAdd(sets);
+  await db.equipamentSets.bulkAdd(sets.map(fromEquipamentSet));
 }

--- a/src/seeds/equipaments.ts
+++ b/src/seeds/equipaments.ts
@@ -1,5 +1,6 @@
 import type { AppDB } from '@/db/db';
 import { Equipament } from '@/models/Equipament';
+import { fromEquipament } from '@/dto/equipament';
 
 export async function seedEquipaments(db: AppDB) {
   const defaultFittings: Equipament[] = [
@@ -14,5 +15,5 @@ export async function seedEquipaments(db: AppDB) {
     new Equipament(9, 'Máquina de Lavar Roupa', 'MLR', 3),
     new Equipament(10, 'Pia', 'PIA', 3),
   ];
-  await db.equipaments.bulkAdd(defaultFittings);
+  await db.equipaments.bulkAdd(defaultFittings.map(fromEquipament));
 }

--- a/src/seeds/levels.ts
+++ b/src/seeds/levels.ts
@@ -1,5 +1,6 @@
 import type { AppDB } from '@/db/db';
 import { Level } from '@/models/Level';
+import { fromLevel } from '@/dto/level';
 
 export async function seedLevels(db: AppDB) {
   const levels: Level[] = [
@@ -49,5 +50,5 @@ export async function seedLevels(db: AppDB) {
     new Level(24, '2º PISO DUPLEX', 44.20),
     new Level(25, 'COBERTA', 47.20)
   ];
-  await db.levels.bulkAdd(levels);
+  await db.levels.bulkAdd(levels.map(fromLevel));
 }

--- a/src/seeds/memorials.ts
+++ b/src/seeds/memorials.ts
@@ -1,10 +1,12 @@
 import type { AppDB } from '@/db/db';
 import { Memorial } from '@/models/Memorial';
+import { toDownPipe } from '@/dto/downPipe';
+import { fromMemorial } from '@/dto/memorial';
 
 export async function seedMemorials(db: AppDB) {
-  const downpipes = await db.downpipes.toArray();
+  const downpipes = (await db.downpipes.toArray()).map(toDownPipe);
   const memorials: Memorial[] = [
     new Memorial(1, 'Memorial Sanitário', downpipes),
   ];
-  await db.memorials.bulkAdd(memorials);
+  await db.memorials.bulkAdd(memorials.map(fromMemorial));
 }

--- a/src/seeds/systems.ts
+++ b/src/seeds/systems.ts
@@ -1,6 +1,7 @@
 import type { AppDB } from '@/db/db';
 import { System } from '@/models/System';
 import { SystemType } from '@/models/enums/SystemType';
+import { fromSystem } from '@/dto/system';
 
 export async function seedSystems(db: AppDB) {
   const systems: System[] = [
@@ -9,5 +10,5 @@ export async function seedSystems(db: AppDB) {
     new System(3, 'Gordura', 'TG', SystemType.Sanitario),
     new System(4, 'Drenagem', 'DR', SystemType.Sanitario),
   ];
-  await db.systems.bulkAdd(systems);
+  await db.systems.bulkAdd(systems.map(fromSystem));
 }


### PR DESCRIPTION
## Summary
- refactor database tables to use DTO types and remove Dexie class mapping
- add conversion helpers between DTOs and domain models
- update repositories and seeds to translate between DTOs and domain objects

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68968db4bd5c83219b9b3e371793a232