### PR TITLE
feat: add reusable entity form dialog

### DIFF
--- a/src/components/EntityFormDialog/EntityFormDialog.tsx
+++ b/src/components/EntityFormDialog/EntityFormDialog.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { Dialog, DialogPanel, DialogTitle, Description } from '@headlessui/react';
+
+import ButtonPrimary from '@/components/Table/ButtonPrimary';
+
+export interface FieldConfig {
+  name: string;
+  label: string;
+  type: string;
+  step?: string;
+}
+
+interface EntityFormDialogProps {
+  fields: FieldConfig[];
+  onSubmit: (data: Record<string, string>) => Promise<void> | void;
+  title: string;
+}
+
+export default function EntityFormDialog({ fields, onSubmit, title }: EntityFormDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const initialData = fields.reduce<Record<string, string>>((acc, field) => {
+    acc[field.name] = '';
+    return acc;
+  }, {});
+  const [data, setData] = useState<Record<string, string>>(initialData);
+
+  function handleChange(name: string, value: string) {
+    setData(prev => ({ ...prev, [name]: value }));
+  }
+
+  async function handleSubmit() {
+    await onSubmit(data);
+    setData(initialData);
+    setIsOpen(false);
+  }
+
+  return (
+    <>
+      <ButtonPrimary onClick={() => setIsOpen(true)} />
+      <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="relative z-50">
+        <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+        <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+          <DialogPanel className="max-w-lg w-full space-y-4 rounded border bg-white p-6">
+            <DialogTitle className="text-lg font-bold">{title}</DialogTitle>
+            <Description>Insira os dados</Description>
+
+            <form
+              className="flex flex-col gap-4"
+              onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }}
+            >
+              {fields.map((field) => (
+                <div key={field.name} className="flex flex-col">
+                  <label htmlFor={field.name} className="text-sm font-medium">{field.label}</label>
+                  <input
+                    id={field.name}
+                    type={field.type}
+                    step={field.step}
+                    value={data[field.name]}
+                    onChange={(e) => handleChange(field.name, e.target.value)}
+                    className="rounded border p-2"
+                    required
+                  />
+                </div>
+              ))}
+
+              <div className="mt-2 flex gap-3">
+                <button type="button" onClick={() => setIsOpen(false)} className="px-4 py-2 rounded border">
+                  Cancelar
+                </button>
+                <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
+                  Adicionar
+                </button>
+              </div>
+            </form>
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </>
+  );
+}
+

--- a/src/pages/EquipamentsEditor/index.tsx
+++ b/src/pages/EquipamentsEditor/index.tsx
@@ -1,106 +1,41 @@
 import { useEffect, useState } from 'react';
 import { Toaster } from 'sonner';
-import { Dialog, DialogPanel, DialogTitle, Description } from '@headlessui/react';
 
 import { Equipament } from '@/models/Equipament';
 import EquipamentRepository from '@/repositories/EquipamentRepository';
 import Table from '@/components/Table/Table';
-import ButtonPrimary from '@/components/Table/ButtonPrimary';
+import EntityFormDialog, { type FieldConfig } from '@/components/EntityFormDialog/EntityFormDialog';
 
 export default function EquipamentsEditor() {
   const [equipaments, setEquipaments] = useState<Equipament[]>([]);
-  const [isOpen, setIsOpen] = useState(false);
-  const [newEquipament, setNewEquipament] = useState<Equipament>(
-    new Equipament('', '', 0)
-  );
 
   useEffect(() => {
     EquipamentRepository.getAll().then(setEquipaments);
   }, []);
 
-  function handleChange<K extends keyof Equipament>(key: K, value: Equipament[K]) {
-    setNewEquipament(prev => new Equipament(
-      key === 'name' ? String(value) : prev.name,
-      key === 'abreviation' ? String(value) : prev.abreviation,
-      key === 'uhc' ? Number(value) : prev.uhc,
-      prev.id
-    ));
-  }
+  const fields: FieldConfig[] = [
+    { name: 'name', label: 'Nome', type: 'text' },
+    { name: 'abreviation', label: 'Abreviação', type: 'text' },
+    { name: 'uhc', label: 'UHC', type: 'number', step: 'any' },
+  ];
 
-  async function handleCreate() {
-    const created = await EquipamentRepository.create(newEquipament);
+  async function handleCreate(data: Record<string, string>) {
+    const equip = new Equipament(
+      data.name,
+      data.abreviation,
+      Number(data.uhc)
+    );
+    const created = await EquipamentRepository.create(equip);
     setEquipaments(prev => [...prev, created]);
-    setIsOpen(false);
-    setNewEquipament(new Equipament('', '', 0));
   }
 
   return (
     <section className="container mx-auto pb-4">
       <Toaster />
-      <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="relative z-50">
-        <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-        <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
-          <DialogPanel className="max-w-lg w-full space-y-4 rounded border bg-white p-6">
-            <DialogTitle className="text-lg font-bold">Adicionar Peça</DialogTitle>
-            <Description>Insira os dados da peça</Description>
-
-            <form
-              className="flex flex-col gap-4"
-              onSubmit={(e) => { e.preventDefault(); void handleCreate(); }}
-            >
-              <div className="flex flex-col">
-                <label htmlFor="name" className="text-sm font-medium">Nome</label>
-                <input
-                  id="name"
-                  type="text"
-                  value={newEquipament.name}
-                  onChange={(e) => handleChange('name', e.target.value)}
-                  className="rounded border p-2"
-                  required
-                />
-              </div>
-
-              <div className="flex flex-col">
-                <label htmlFor="abreviation" className="text-sm font-medium">Abreviação</label>
-                <input
-                  id="abreviation"
-                  type="text"
-                  value={newEquipament.abreviation}
-                  onChange={(e) => handleChange('abreviation', e.target.value)}
-                  className="rounded border p-2"
-                  required
-                />
-              </div>
-
-              <div className="flex flex-col">
-                <label htmlFor="uhc" className="text-sm font-medium">UHC</label>
-                <input
-                  id="uhc"
-                  type="number"
-                  step="any"
-                  value={String(newEquipament.uhc)}
-                  onChange={(e) => handleChange('uhc', Number(e.target.value))}
-                  className="rounded border p-2"
-                  required
-                />
-              </div>
-
-              <div className="mt-2 flex gap-3">
-                <button type="button" onClick={() => setIsOpen(false)} className="px-4 py-2 rounded border">
-                  Cancelar
-                </button>
-                <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
-                  Adicionar
-                </button>
-              </div>
-            </form>
-          </DialogPanel>
-        </div>
-      </Dialog>
 
       <div className="menu flex justify-between items-center py-4">
         <h1 className="font-semibold">Menu de Edição de Peças Hidráulicas</h1>
-        <ButtonPrimary onClick={() => setIsOpen(true)} />
+        <EntityFormDialog title="Adicionar Peça" fields={fields} onSubmit={handleCreate} />
       </div>
 
       <Table data={equipaments} />

--- a/src/pages/LevelsEditor/index.tsx
+++ b/src/pages/LevelsEditor/index.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { Toaster } from "sonner";
-import type { Level } from "@/models/Level";
+import { Level } from "@/models/Level";
 import LevelRepository from "@/repositories/LevelRepository";
 import Table from "@/components/Table/Table";
+import EntityFormDialog, { type FieldConfig } from "@/components/EntityFormDialog/EntityFormDialog";
 
 export default function LevelsEditor() {
   const [levels, setLevels] = useState<Level[]>([]);
@@ -11,10 +12,26 @@ export default function LevelsEditor() {
     LevelRepository.getAll().then(setLevels);
   }, []);
 
+  const fields: FieldConfig[] = [
+    { name: "name", label: "Nome", type: "text" },
+    { name: "height", label: "Altura", type: "number", step: "any" },
+  ];
+
+  async function handleCreate(data: Record<string, string>) {
+    const level = new Level(data.name, Number(data.height));
+    const created = await LevelRepository.create(level);
+    setLevels(prev => [...prev, created]);
+  }
+
   return (
     <section className="container mx-auto">
       <Toaster />
-      <h1 className="my-4">Níveis</h1>
+
+      <div className="menu flex justify-between items-center py-4">
+        <h1 className="font-semibold">Níveis</h1>
+        <EntityFormDialog title="Adicionar Nível" fields={fields} onSubmit={handleCreate} />
+      </div>
+
       <Table data={levels} />
     </section>
   );


### PR DESCRIPTION
## Summary
- add generic EntityFormDialog component for dynamic forms
- refactor EquipamentsEditor to use the new dialog
- reuse dialog in LevelsEditor for adding levels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896943a4abc83218fe8b1d5b749bfa2