### PR TITLE
Add success toast notifications when creating entities

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,1 @@
+export const ENTITY_ADDED_SUCCESS = 'Entidade adicionada com sucesso';

--- a/src/pages/EquipamentsEditor/index.tsx
+++ b/src/pages/EquipamentsEditor/index.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Toaster } from 'sonner';
+import { Toaster, toast } from 'sonner';
 
 import { Equipament } from '@/models/Equipament';
 import EquipamentRepository from '@/repositories/EquipamentRepository';
 import Table from '@/components/Table/Table';
 import EntityFormDialog, { type FieldConfig } from '@/components/EntityFormDialog/EntityFormDialog';
 import SectionMain from '@/components/SectionMain/SectionMain';
+import { ENTITY_ADDED_SUCCESS } from '@/constants/messages';
 
 export default function EquipamentsEditor() {
   const [equipaments, setEquipaments] = useState<Equipament[]>([]);
@@ -28,6 +29,7 @@ export default function EquipamentsEditor() {
     );
     const created = await EquipamentRepository.create(equip);
     setEquipaments(prev => [...prev, created]);
+    toast.success(ENTITY_ADDED_SUCCESS);
   }
 
   return (

--- a/src/pages/LevelsEditor/index.tsx
+++ b/src/pages/LevelsEditor/index.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
 import { Level } from "@/models/Level";
 import LevelRepository from "@/repositories/LevelRepository";
 import Table from "@/components/Table/Table";
 import EntityFormDialog, { type FieldConfig } from "@/components/EntityFormDialog/EntityFormDialog";
 import SectionMain from "@/components/SectionMain/SectionMain";
+import { ENTITY_ADDED_SUCCESS } from "@/constants/messages";
 
 export default function LevelsEditor() {
   const [levels, setLevels] = useState<Level[]>([]);
@@ -22,6 +23,7 @@ export default function LevelsEditor() {
     const level = new Level(data.name, Number(data.height));
     const created = await LevelRepository.create(level);
     setLevels(prev => [...prev, created]);
+    toast.success(ENTITY_ADDED_SUCCESS);
   }
 
   return (


### PR DESCRIPTION
## Summary
- notify user after creating equipment or level via `toast.success`
- extract shared success message for reuse across editors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7c7da2f8832198738b5b4085bdbf