### PR TITLE
Add Vitest config and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,13 @@ classDiagram
         +Equipament|EquipamentSet equipament
         +totaluhc()
     }
+
+```
+
+## 🧪 Testes
+
+Execute os testes unitários com o comando:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",
@@ -27,6 +28,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/ui": "^2.1.4",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
@@ -34,6 +36,7 @@
     "react-router-dom": "^7.6.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^2.1.4"
   }
 }

--- a/src/tests/mappers.test.ts
+++ b/src/tests/mappers.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toContribution,
+  type ContributionDTO,
+  type HydratedContributionDTO,
+} from '@/dto/contribution'
+import {
+  toEquipamentSet,
+  type EquipamentSetDTO,
+} from '@/dto/equipamentSet'
+import { toDownPipe, type DownPipeDTO } from '@/dto/downPipe'
+import { type LevelDTO } from '@/dto/level'
+import { type EquipamentDTO } from '@/dto/equipament'
+import { type SystemDTO } from '@/dto/system'
+import { SystemType } from '@/models/enums/SystemType'
+import { Contribution, HydratedContribution } from '@/models/Contribution'
+import { Equipament } from '@/models/Equipament'
+import { EquipamentSet } from '@/models/EquipamentSet'
+import { DownPipe } from '@/models/DownPipe'
+
+
+describe('DTO mappers', () => {
+  it('converts ContributionDTO to Contribution', () => {
+    const dto: ContributionDTO = { id: 1, levelId: 2, equipamentId: 3 }
+    const model = toContribution(dto)
+    expect(model).toBeInstanceOf(Contribution)
+    expect(model).toMatchObject(dto)
+  })
+
+  it('converts nested EquipamentSetDTO to EquipamentSet', () => {
+    const dto: EquipamentSetDTO = {
+      id: 1,
+      name: 'Set',
+      equipaments: [
+        { id: 2, name: 'E1', abreviation: 'E1', uhc: 5 } as EquipamentDTO,
+        {
+          id: 3,
+          name: 'Nested',
+          equipaments: [
+            { id: 4, name: 'E2', abreviation: 'E2', uhc: 7 } as EquipamentDTO,
+          ],
+        },
+      ],
+    }
+    const model = toEquipamentSet(dto)
+    expect(model).toBeInstanceOf(EquipamentSet)
+    expect(model.equipaments[0]).toBeInstanceOf(Equipament)
+    expect(model.equipaments[1]).toBeInstanceOf(EquipamentSet)
+  })
+
+  it('converts DownPipeDTO to DownPipe', () => {
+    const level: LevelDTO = { id: 1, name: 'Nível 1', height: 0 }
+    const equip: EquipamentDTO = {
+      id: 1,
+      name: 'E1',
+      abreviation: 'E1',
+      uhc: 10,
+    }
+    const contributionDto: HydratedContributionDTO = {
+      id: 1,
+      level,
+      equipament: equip,
+    }
+    const system: SystemDTO = {
+      id: 1,
+      name: 'Sistema',
+      systemAbreviation: 'S',
+      systemType: SystemType.Hidraulico,
+    }
+    const dto: DownPipeDTO = {
+      id: 1,
+      numeration: '1',
+      diameter: 100,
+      system,
+      contributions: [contributionDto],
+    }
+    const model = toDownPipe(dto)
+    expect(model).toBeInstanceOf(DownPipe)
+    expect(model.system.systemAbreviation).toBe('S')
+    expect(model.contributions[0]).toBeInstanceOf(HydratedContribution)
+    expect(model.contributions[0].equipament).toBeInstanceOf(Equipament)
+  })
+})
+

--- a/src/tests/totaluhc.test.ts
+++ b/src/tests/totaluhc.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { HydratedContribution } from '@/models/Contribution'
+import { Level } from '@/models/Level'
+import { Equipament } from '@/models/Equipament'
+import { EquipamentSet } from '@/models/EquipamentSet'
+import { DownPipe } from '@/models/DownPipe'
+import { System } from '@/models/System'
+import { SystemType } from '@/models/enums/SystemType'
+
+describe('totaluhc calculations', () => {
+  it('calculates totaluhc for HydratedContribution with Equipament', () => {
+    const level = new Level('N1', 0)
+    const equip = new Equipament('E1', 'E1', 10)
+    const contribution = new HydratedContribution(level, equip)
+    expect(contribution.totaluhc).toBe(10)
+  })
+
+  it('calculates totaluhc for HydratedContribution with EquipamentSet', () => {
+    const level = new Level('N1', 0)
+    const e1 = new Equipament('E1', 'E1', 10)
+    const e2 = new Equipament('E2', 'E2', 15)
+    const set = new EquipamentSet('Set', [e1, e2])
+    const contribution = new HydratedContribution(level, set)
+    expect(contribution.totaluhc).toBe(25)
+  })
+
+  it('calculates totaluhc for nested EquipamentSet', () => {
+    const e1 = new Equipament('E1', 'E1', 10)
+    const e2 = new Equipament('E2', 'E2', 15)
+    const inner = new EquipamentSet('Inner', [e2])
+    const root = new EquipamentSet('Root', [e1, inner])
+    expect(root.totaluhc).toBe(25)
+  })
+
+  it('calculates totaluhc for DownPipe', () => {
+    const level = new Level('N1', 0)
+    const e1 = new Equipament('E1', 'E1', 10)
+    const e2 = new Equipament('E2', 'E2', 20)
+    const c1 = new HydratedContribution(level, e1)
+    const c2 = new HydratedContribution(level, e2)
+    const system = new System('Sistema', 'S', SystemType.Hidraulico)
+    const pipe = new DownPipe('1', 100, system, [c1, c2])
+    expect(pipe.totaluhc).toBe(30)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
## Summary
- add Vitest and UI dev deps with test script
- configure Vitest with tsconfig path resolution
- add unit tests for DTO mapping and total UHC calculations
- document test command in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a7d4a1fd08321b16292fe35f642a0