### PR TITLE
feat: add edit/delete actions to tables

### DIFF
--- a/src/components/EntityFormDialog/EntityFormDialog.tsx
+++ b/src/components/EntityFormDialog/EntityFormDialog.tsx
@@ -4,104 +4,104 @@ import { Dialog, DialogPanel, DialogTitle, Description } from '@headlessui/react
 import ButtonPrimary from '@/components/Table/ButtonPrimary';
 
 export interface FieldConfig {
-  name: string;
-  label: string;
-  type: string;
-  step?: string;
+    name: string;
+    label: string;
+    type: string;
+    step?: string;
 }
 
 interface EntityFormDialogProps {
-  fields: FieldConfig[];
-  onSubmit: (data: Record<string, string>) => Promise<void> | void;
-  title: string;
-  initialData?: Record<string, string>;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
-  hideTrigger?: boolean;
-  submitLabel?: string;
+    fields: FieldConfig[];
+    onSubmit: (data: Record<string, string>) => Promise<void> | void;
+    title: string;
+    initialData?: Record<string, string>;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    hideTrigger?: boolean;
+    submitLabel?: string;
 }
 
 export default function EntityFormDialog({
-  fields,
-  onSubmit,
-  title,
-  initialData,
-  open,
-  onOpenChange,
-  hideTrigger,
-  submitLabel = 'Adicionar',
+    fields,
+    onSubmit,
+    title,
+    initialData,
+    open,
+    onOpenChange,
+    hideTrigger,
+    submitLabel = 'Adicionar',
 }: EntityFormDialogProps) {
-  const controlled = open !== undefined && onOpenChange !== undefined;
-  const [internalOpen, setInternalOpen] = useState(false);
-  const isOpen = controlled ? open : internalOpen;
-  const setIsOpen = controlled ? onOpenChange! : setInternalOpen;
+    const controlled = open !== undefined && onOpenChange !== undefined;
+    const [internalOpen, setInternalOpen] = useState(false);
+    const isOpen = controlled ? open : internalOpen;
+    const setIsOpen = controlled ? onOpenChange! : setInternalOpen;
 
-  const emptyData = useMemo(
-    () =>
-      fields.reduce<Record<string, string>>((acc, field) => {
-        acc[field.name] = '';
-        return acc;
-      }, {}),
-    [fields]
-  );
+    const emptyData = useMemo(
+        () =>
+            fields.reduce<Record<string, string>>((acc, field) => {
+                acc[field.name] = '';
+                return acc;
+            }, {}),
+        [fields]
+    );
 
-  const [data, setData] = useState<Record<string, string>>(initialData ?? emptyData);
+    const [data, setData] = useState<Record<string, string>>(initialData ?? emptyData);
 
-  useEffect(() => {
-    setData(initialData ?? emptyData);
-  }, [initialData, emptyData]);
+    useEffect(() => {
+        setData(initialData ?? emptyData);
+    }, [initialData, emptyData]);
 
-  function handleChange(name: string, value: string) {
-    setData(prev => ({ ...prev, [name]: value }));
-  }
+    function handleChange(name: string, value: string) {
+        setData(prev => ({ ...prev, [name]: value }));
+    }
 
-  async function handleSubmit() {
-    await onSubmit(data);
-    setData(emptyData);
-    setIsOpen(false);
-  }
+    async function handleSubmit() {
+        await onSubmit(data);
+        setData(emptyData);
+        setIsOpen(false);
+    }
 
-  return (
-    <>
-      {!hideTrigger && <ButtonPrimary onClick={() => setIsOpen(true)} />}
-      <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="relative z-50">
-        <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-        <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
-          <DialogPanel className="max-w-lg w-full space-y-4 rounded border bg-white p-6">
-            <DialogTitle className="text-lg font-bold">{title}</DialogTitle>
-            <Description>Insira os dados</Description>
+    return (
+        <>
+            {!hideTrigger && <ButtonPrimary onClick={() => setIsOpen(true)} />}
+            <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="relative z-50">
+                <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+                <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+                    <DialogPanel className="max-w-lg w-full space-y-4 rounded border bg-white p-6">
+                        <DialogTitle className="text-lg font-bold">{title}</DialogTitle>
+                        <Description>Insira os dados</Description>
 
-            <form
-              className="flex flex-col gap-4"
-              onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }}
-            >
-              {fields.map((field) => (
-                <div key={field.name} className="flex flex-col">
-                  <label htmlFor={field.name} className="text-sm font-medium">{field.label}</label>
-                  <input
-                    id={field.name}
-                    type={field.type}
-                    step={field.step}
-                    value={data[field.name]}
-                    onChange={(e) => handleChange(field.name, e.target.value)}
-                    className="rounded border p-2"
-                    required
-                  />
+                        <form
+                            className="flex flex-col gap-4"
+                            onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }}
+                        >
+                            {fields.map((field) => (
+                                <div key={field.name} className="flex flex-col">
+                                    <label htmlFor={field.name} className="text-sm font-medium">{field.label}</label>
+                                    <input
+                                        id={field.name}
+                                        type={field.type}
+                                        step={field.step}
+                                        value={data[field.name]}
+                                        onChange={(e) => handleChange(field.name, e.target.value)}
+                                        className="rounded border p-2"
+                                        required
+                                    />
+                                </div>
+                            ))}
+
+                            <div className="mt-2 flex gap-3">
+                                <button type="button" onClick={() => setIsOpen(false)} className="px-4 py-2 rounded border">
+                                    Cancelar
+                                </button>
+                                <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
+                                    {submitLabel}
+                                </button>
+                            </div>
+                        </form>
+                    </DialogPanel>
                 </div>
-              ))}
-
-              <div className="mt-2 flex gap-3">
-                <button type="button" onClick={() => setIsOpen(false)} className="px-4 py-2 rounded border">
-                  Cancelar
-                </button>
-                <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
-                  {submitLabel}
-                </button>
-              </div>
-            </form>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </>
-  );
+            </Dialog>
+        </>
+    );
 }

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,80 +1,80 @@
 import type { IElement } from "@/models/InterfaceElement";
 
 interface TableProps {
-  data: IElement[];
-  onEdit?: (id: number) => void;
-  onDelete?: (id: number) => void;
+    data: IElement[];
+    onEdit?: (id: number) => void;
+    onDelete?: (id: number) => void;
 }
 
 const Table = ({ data, onEdit, onDelete }: TableProps) => {
-  const dataToRender = data.map((item) => item.toTableRow());
-  const columns = Object.keys(dataToRender[0] ?? {});
+    const dataToRender = data.map((item) => item.toTableRow());
+    const columns = Object.keys(dataToRender[0] ?? {});
 
-  return (
-    <table className="table-auto w-full">
-      <thead className="bg-stone-200">
-        <tr>
-          {columns.map((column) => (
-            <th key={column} className="border border-stone-300 p-2">
-              {column}
-            </th>
-          ))}
-          {(onEdit || onDelete) && (
-            <th className="border border-stone-300 p-2">Ações</th>
-          )}
-        </tr>
-      </thead>
-      <tbody>
-        {dataToRender.map((row, index) => {
-          const rowId = row["ID"]?.value;
-          const key =
-            typeof rowId === "string" || typeof rowId === "number"
-              ? rowId
-              : index;
-          const idNumber = typeof rowId === "number" ? rowId : Number(rowId);
+    return (
+        <table className="table-auto w-full">
+            <thead className="bg-stone-200">
+                <tr>
+                    {columns.map((column) => (
+                        <th key={column} className="border border-stone-300 p-2">
+                            {column}
+                        </th>
+                    ))}
+                    {(onEdit || onDelete) && (
+                        <th className="border border-stone-300 p-2">Ações</th>
+                    )}
+                </tr>
+            </thead>
+            <tbody>
+                {dataToRender.map((row, index) => {
+                    const rowId = row["ID"]?.value;
+                    const key =
+                        typeof rowId === "string" || typeof rowId === "number"
+                            ? rowId
+                            : index;
+                    const idNumber = typeof rowId === "number" ? rowId : Number(rowId);
 
-          return (
-            <tr className="even:bg-stone-100" key={key}>
-              {columns.map((column) => {
-                const cell = row[column];
-                const alignClass = cell?.align ? `text-${cell.align}` : "";
-                return (
-                  <td
-                    key={column}
-                    className={`${alignClass} border border-stone-300 p-2`}
-                  >
-                    {cell?.value}
-                  </td>
-                );
-              })}
-              {(onEdit || onDelete) && (
-                <td className="border border-stone-300 p-2 text-center space-x-2">
-                  {onEdit && (
-                    <button
-                      type="button"
-                      onClick={() => onEdit(idNumber)}
-                      className="px-1"
-                    >
-                      ✏️
-                    </button>
-                  )}
-                  {onDelete && (
-                    <button
-                      type="button"
-                      onClick={() => onDelete(idNumber)}
-                      className="px-1"
-                    >
-                      🗑️
-                    </button>
-                  )}
-                </td>
-              )}
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
-  );
+                    return (
+                        <tr className="even:bg-stone-100" key={key}>
+                            {columns.map((column) => {
+                                const cell = row[column];
+                                const alignClass = cell?.align ? `text-${cell.align}` : "";
+                                return (
+                                    <td
+                                        key={column}
+                                        className={`${alignClass} border border-stone-300 p-2`}
+                                    >
+                                        {cell?.value}
+                                    </td>
+                                );
+                            })}
+                            {(onEdit || onDelete) && (
+                                <td className="border border-stone-300 p-2 text-center space-x-2">
+                                    {onEdit && (
+                                        <button
+                                            type="button"
+                                            onClick={() => onEdit(idNumber)}
+                                            className="px-1"
+                                        >
+                                            ✏️
+                                        </button>
+                                    )}
+                                    {onDelete && (
+                                        <button
+                                            type="button"
+                                            onClick={() => onDelete(idNumber)}
+                                            className="px-1"
+                                        >
+                                            🗑️
+                                        </button>
+                                    )}
+                                </td>
+                            )}
+                        </tr>
+                    );
+                })}
+            </tbody>
+        </table>
+    );
 };
 
 export default Table;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,48 +1,80 @@
 import type { IElement } from "@/models/InterfaceElement";
 
 interface TableProps {
-    data: IElement[];
-  }
-  
-  const Table = ({ data }: TableProps) => {
-    const dataToRender = data.map((item) => item.toTableRow());
-    const columns = Object.keys(dataToRender[0] ?? {});
-  
-    return (
-      <table className="table-auto w-full">
-        <thead className="bg-stone-200">
-          <tr>
-            {columns.map((column) => (
-              <th key={column} className="border border-stone-300 p-2">{column}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {dataToRender.map((row, index) => {
-            const rowId = row["ID"]?.value;
-            const key = typeof rowId === "string" || typeof rowId === "number" ? rowId : index;
+  data: IElement[];
+  onEdit?: (id: number) => void;
+  onDelete?: (id: number) => void;
+}
 
-            return (
-              <tr className="even:bg-stone-100" key={key}>
-                {columns.map((column) => {
-                  const cell = row[column];
-                  const alignClass = cell?.align ? `text-${cell.align}` : "";
-                  return (
-                    <td
-                      key={column}
-                      className={`${alignClass} border border-stone-300 p-2`}
+const Table = ({ data, onEdit, onDelete }: TableProps) => {
+  const dataToRender = data.map((item) => item.toTableRow());
+  const columns = Object.keys(dataToRender[0] ?? {});
+
+  return (
+    <table className="table-auto w-full">
+      <thead className="bg-stone-200">
+        <tr>
+          {columns.map((column) => (
+            <th key={column} className="border border-stone-300 p-2">
+              {column}
+            </th>
+          ))}
+          {(onEdit || onDelete) && (
+            <th className="border border-stone-300 p-2">Ações</th>
+          )}
+        </tr>
+      </thead>
+      <tbody>
+        {dataToRender.map((row, index) => {
+          const rowId = row["ID"]?.value;
+          const key =
+            typeof rowId === "string" || typeof rowId === "number"
+              ? rowId
+              : index;
+          const idNumber = typeof rowId === "number" ? rowId : Number(rowId);
+
+          return (
+            <tr className="even:bg-stone-100" key={key}>
+              {columns.map((column) => {
+                const cell = row[column];
+                const alignClass = cell?.align ? `text-${cell.align}` : "";
+                return (
+                  <td
+                    key={column}
+                    className={`${alignClass} border border-stone-300 p-2`}
+                  >
+                    {cell?.value}
+                  </td>
+                );
+              })}
+              {(onEdit || onDelete) && (
+                <td className="border border-stone-300 p-2 text-center space-x-2">
+                  {onEdit && (
+                    <button
+                      type="button"
+                      onClick={() => onEdit(idNumber)}
+                      className="px-1"
                     >
-                      {cell?.value}
-                    </td>
-                  );
-                })}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    );
-  };
-  
-  export default Table;
-  
+                      ✏️
+                    </button>
+                  )}
+                  {onDelete && (
+                    <button
+                      type="button"
+                      onClick={() => onDelete(idNumber)}
+                      className="px-1"
+                    >
+                      🗑️
+                    </button>
+                  )}
+                </td>
+              )}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
+export default Table;

--- a/src/pages/EquipamentsEditor/index.tsx
+++ b/src/pages/EquipamentsEditor/index.tsx
@@ -10,112 +10,112 @@ import SectionMain from '@/components/SectionMain/SectionMain';
 import { ENTITY_ADDED_SUCCESS } from '@/constants/messages';
 
 export default function EquipamentsEditor() {
-  const [equipaments, setEquipaments] = useState<Equipament[]>([]);
-  const [editing, setEditing] = useState<Equipament | null>(null);
-  const [isEditOpen, setIsEditOpen] = useState(false);
-  const [deleteId, setDeleteId] = useState<number | null>(null);
+    const [equipaments, setEquipaments] = useState<Equipament[]>([]);
+    const [editing, setEditing] = useState<Equipament | null>(null);
+    const [isEditOpen, setIsEditOpen] = useState(false);
+    const [deleteId, setDeleteId] = useState<number | null>(null);
 
-  useEffect(() => {
-    EquipamentRepository.getAll().then(setEquipaments);
-  }, []);
+    useEffect(() => {
+        EquipamentRepository.getAll().then(setEquipaments);
+    }, []);
 
-  const fields: FieldConfig[] = [
-    { name: 'name', label: 'Nome', type: 'text' },
-    { name: 'abreviation', label: 'Abreviação', type: 'text' },
-    { name: 'uhc', label: 'UHC', type: 'number', step: '1' },
-  ];
+    const fields: FieldConfig[] = [
+        { name: 'name', label: 'Nome', type: 'text' },
+        { name: 'abreviation', label: 'Abreviação', type: 'text' },
+        { name: 'uhc', label: 'UHC', type: 'number', step: '1' },
+    ];
 
-  async function handleCreate(data: Record<string, string>) {
-    const equip = new Equipament(
-      data.name,
-      data.abreviation,
-      Number(data.uhc)
+    async function handleCreate(data: Record<string, string>) {
+        const equip = new Equipament(
+            data.name,
+            data.abreviation,
+            Number(data.uhc)
+        );
+        const created = await EquipamentRepository.create(equip);
+        setEquipaments(prev => [...prev, created]);
+        toast.success(ENTITY_ADDED_SUCCESS);
+    }
+
+    function openEdit(id: number) {
+        const equip = equipaments.find(e => e.id === id);
+        if (!equip) return;
+        setEditing(equip);
+        setIsEditOpen(true);
+    }
+
+    async function handleEdit(data: Record<string, string>) {
+        if (!editing?.id) return;
+        await EquipamentRepository.update(editing.id, {
+            name: data.name,
+            abreviation: data.abreviation,
+            uhc: Number(data.uhc),
+        });
+        setEquipaments(prev =>
+            prev.map(e =>
+                e.id === editing.id
+                    ? new Equipament(data.name, data.abreviation, Number(data.uhc), editing.id)
+                    : e
+            )
+        );
+        setIsEditOpen(false);
+        setEditing(null);
+    }
+
+    function openDelete(id: number) {
+        setDeleteId(id);
+    }
+
+    async function confirmDelete() {
+        if (deleteId === null) return;
+        await EquipamentRepository.delete(deleteId);
+        setEquipaments(prev => prev.filter(e => e.id !== deleteId));
+        setDeleteId(null);
+    }
+
+    const editInitialData = editing
+        ? { name: editing.name, abreviation: editing.abreviation, uhc: String(editing.uhc) }
+        : undefined;
+
+    return (
+        <SectionMain>
+            <Toaster />
+            <div className="menu flex justify-between items-center py-4">
+                <h1 className="font-semibold">Peças</h1>
+                <EntityFormDialog title="Adicionar Peça" fields={fields} onSubmit={handleCreate} />
+            </div>
+            <Table data={equipaments} onEdit={openEdit} onDelete={openDelete} />
+            <EntityFormDialog
+                title="Editar Peça"
+                fields={fields}
+                onSubmit={handleEdit}
+                open={isEditOpen}
+                onOpenChange={(open) => {
+                    setIsEditOpen(open);
+                    if (!open) setEditing(null);
+                }}
+                initialData={editInitialData}
+                hideTrigger
+                submitLabel="Salvar"
+            />
+            {deleteId !== null && (
+                <Dialog open={true} onClose={() => setDeleteId(null)} className="relative z-50">
+                    <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+                    <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+                        <DialogPanel className="max-w-md w-full space-y-4 rounded border bg-white p-6">
+                            <DialogTitle className="text-lg font-bold">Confirmar exclusão</DialogTitle>
+                            <p>Deseja remover esta peça?</p>
+                            <div className="mt-2 flex gap-3">
+                                <button type="button" onClick={() => setDeleteId(null)} className="px-4 py-2 rounded border">
+                                    Cancelar
+                                </button>
+                                <button type="button" onClick={() => void confirmDelete()} className="px-4 py-2 rounded bg-red-600 text-white">
+                                    Excluir
+                                </button>
+                            </div>
+                        </DialogPanel>
+                    </div>
+                </Dialog>
+            )}
+        </SectionMain>
     );
-    const created = await EquipamentRepository.create(equip);
-    setEquipaments(prev => [...prev, created]);
-    toast.success(ENTITY_ADDED_SUCCESS);
-  }
-
-  function openEdit(id: number) {
-    const equip = equipaments.find(e => e.id === id);
-    if (!equip) return;
-    setEditing(equip);
-    setIsEditOpen(true);
-  }
-
-  async function handleEdit(data: Record<string, string>) {
-    if (!editing?.id) return;
-    await EquipamentRepository.update(editing.id, {
-      name: data.name,
-      abreviation: data.abreviation,
-      uhc: Number(data.uhc),
-    });
-    setEquipaments(prev =>
-      prev.map(e =>
-        e.id === editing.id
-          ? new Equipament(data.name, data.abreviation, Number(data.uhc), editing.id)
-          : e
-      )
-    );
-    setIsEditOpen(false);
-    setEditing(null);
-  }
-
-  function openDelete(id: number) {
-    setDeleteId(id);
-  }
-
-  async function confirmDelete() {
-    if (deleteId === null) return;
-    await EquipamentRepository.delete(deleteId);
-    setEquipaments(prev => prev.filter(e => e.id !== deleteId));
-    setDeleteId(null);
-  }
-
-  const editInitialData = editing
-    ? { name: editing.name, abreviation: editing.abreviation, uhc: String(editing.uhc) }
-    : undefined;
-
-  return (
-    <SectionMain>
-      <Toaster />
-      <div className="menu flex justify-between items-center py-4">
-        <h1 className="font-semibold">Peças</h1>
-        <EntityFormDialog title="Adicionar Peça" fields={fields} onSubmit={handleCreate} />
-      </div>
-      <Table data={equipaments} onEdit={openEdit} onDelete={openDelete} />
-      <EntityFormDialog
-        title="Editar Peça"
-        fields={fields}
-        onSubmit={handleEdit}
-        open={isEditOpen}
-        onOpenChange={(open) => {
-          setIsEditOpen(open);
-          if (!open) setEditing(null);
-        }}
-        initialData={editInitialData}
-        hideTrigger
-        submitLabel="Salvar"
-      />
-      {deleteId !== null && (
-        <Dialog open={true} onClose={() => setDeleteId(null)} className="relative z-50">
-          <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-          <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
-            <DialogPanel className="max-w-md w-full space-y-4 rounded border bg-white p-6">
-              <DialogTitle className="text-lg font-bold">Confirmar exclusão</DialogTitle>
-              <p>Deseja remover esta peça?</p>
-              <div className="mt-2 flex gap-3">
-                <button type="button" onClick={() => setDeleteId(null)} className="px-4 py-2 rounded border">
-                  Cancelar
-                </button>
-                <button type="button" onClick={() => void confirmDelete()} className="px-4 py-2 rounded bg-red-600 text-white">
-                  Excluir
-                </button>
-              </div>
-            </DialogPanel>
-          </div>
-        </Dialog>
-      )}
-    </SectionMain>
-  );
 }

--- a/src/pages/EquipamentsEditor/index.tsx
+++ b/src/pages/EquipamentsEditor/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { Toaster, toast } from 'sonner';
 
 import { Equipament } from '@/models/Equipament';
@@ -10,6 +11,9 @@ import { ENTITY_ADDED_SUCCESS } from '@/constants/messages';
 
 export default function EquipamentsEditor() {
   const [equipaments, setEquipaments] = useState<Equipament[]>([]);
+  const [editing, setEditing] = useState<Equipament | null>(null);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
 
   useEffect(() => {
     EquipamentRepository.getAll().then(setEquipaments);
@@ -32,6 +36,46 @@ export default function EquipamentsEditor() {
     toast.success(ENTITY_ADDED_SUCCESS);
   }
 
+  function openEdit(id: number) {
+    const equip = equipaments.find(e => e.id === id);
+    if (!equip) return;
+    setEditing(equip);
+    setIsEditOpen(true);
+  }
+
+  async function handleEdit(data: Record<string, string>) {
+    if (!editing?.id) return;
+    await EquipamentRepository.update(editing.id, {
+      name: data.name,
+      abreviation: data.abreviation,
+      uhc: Number(data.uhc),
+    });
+    setEquipaments(prev =>
+      prev.map(e =>
+        e.id === editing.id
+          ? new Equipament(data.name, data.abreviation, Number(data.uhc), editing.id)
+          : e
+      )
+    );
+    setIsEditOpen(false);
+    setEditing(null);
+  }
+
+  function openDelete(id: number) {
+    setDeleteId(id);
+  }
+
+  async function confirmDelete() {
+    if (deleteId === null) return;
+    await EquipamentRepository.delete(deleteId);
+    setEquipaments(prev => prev.filter(e => e.id !== deleteId));
+    setDeleteId(null);
+  }
+
+  const editInitialData = editing
+    ? { name: editing.name, abreviation: editing.abreviation, uhc: String(editing.uhc) }
+    : undefined;
+
   return (
     <SectionMain>
       <Toaster />
@@ -39,7 +83,39 @@ export default function EquipamentsEditor() {
         <h1 className="font-semibold">Peças</h1>
         <EntityFormDialog title="Adicionar Peça" fields={fields} onSubmit={handleCreate} />
       </div>
-      <Table data={equipaments} />
+      <Table data={equipaments} onEdit={openEdit} onDelete={openDelete} />
+      <EntityFormDialog
+        title="Editar Peça"
+        fields={fields}
+        onSubmit={handleEdit}
+        open={isEditOpen}
+        onOpenChange={(open) => {
+          setIsEditOpen(open);
+          if (!open) setEditing(null);
+        }}
+        initialData={editInitialData}
+        hideTrigger
+        submitLabel="Salvar"
+      />
+      {deleteId !== null && (
+        <Dialog open={true} onClose={() => setDeleteId(null)} className="relative z-50">
+          <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+          <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+            <DialogPanel className="max-w-md w-full space-y-4 rounded border bg-white p-6">
+              <DialogTitle className="text-lg font-bold">Confirmar exclusão</DialogTitle>
+              <p>Deseja remover esta peça?</p>
+              <div className="mt-2 flex gap-3">
+                <button type="button" onClick={() => setDeleteId(null)} className="px-4 py-2 rounded border">
+                  Cancelar
+                </button>
+                <button type="button" onClick={() => void confirmDelete()} className="px-4 py-2 rounded bg-red-600 text-white">
+                  Excluir
+                </button>
+              </div>
+            </DialogPanel>
+          </div>
+        </Dialog>
+      )}
     </SectionMain>
   );
 }

--- a/src/pages/LevelsEditor/index.tsx
+++ b/src/pages/LevelsEditor/index.tsx
@@ -9,106 +9,106 @@ import SectionMain from "@/components/SectionMain/SectionMain";
 import { ENTITY_ADDED_SUCCESS } from "@/constants/messages";
 
 export default function LevelsEditor() {
-  const [levels, setLevels] = useState<Level[]>([]);
-  const [editing, setEditing] = useState<Level | null>(null);
-  const [isEditOpen, setIsEditOpen] = useState(false);
-  const [deleteId, setDeleteId] = useState<number | null>(null);
+    const [levels, setLevels] = useState<Level[]>([]);
+    const [editing, setEditing] = useState<Level | null>(null);
+    const [isEditOpen, setIsEditOpen] = useState(false);
+    const [deleteId, setDeleteId] = useState<number | null>(null);
 
-  useEffect(() => {
-    LevelRepository.getAll().then(setLevels);
-  }, []);
+    useEffect(() => {
+        LevelRepository.getAll().then(setLevels);
+    }, []);
 
-  const fields: FieldConfig[] = [
-    { name: "name", label: "Nome", type: "text" },
-    { name: "height", label: "Altura", type: "number", step: "any" },
-  ];
+    const fields: FieldConfig[] = [
+        { name: "name", label: "Nome", type: "text" },
+        { name: "height", label: "Altura", type: "number", step: "any" },
+    ];
 
-  async function handleCreate(data: Record<string, string>) {
-    const level = new Level(data.name, Number(data.height));
-    const created = await LevelRepository.create(level);
-    setLevels(prev => [...prev, created]);
-    toast.success(ENTITY_ADDED_SUCCESS);
-  }
+    async function handleCreate(data: Record<string, string>) {
+        const level = new Level(data.name, Number(data.height));
+        const created = await LevelRepository.create(level);
+        setLevels(prev => [...prev, created]);
+        toast.success(ENTITY_ADDED_SUCCESS);
+    }
 
-  function openEdit(id: number) {
-    const level = levels.find(l => l.id === id);
-    if (!level) return;
-    setEditing(level);
-    setIsEditOpen(true);
-  }
+    function openEdit(id: number) {
+        const level = levels.find(l => l.id === id);
+        if (!level) return;
+        setEditing(level);
+        setIsEditOpen(true);
+    }
 
-  async function handleEdit(data: Record<string, string>) {
-    if (!editing?.id) return;
-    await LevelRepository.update(editing.id, {
-      name: data.name,
-      height: Number(data.height),
-    });
-    setLevels(prev =>
-      prev.map(l =>
-        l.id === editing.id
-          ? new Level(data.name, Number(data.height), editing.id)
-          : l
-      )
+    async function handleEdit(data: Record<string, string>) {
+        if (!editing?.id) return;
+        await LevelRepository.update(editing.id, {
+            name: data.name,
+            height: Number(data.height),
+        });
+        setLevels(prev =>
+            prev.map(l =>
+                l.id === editing.id
+                    ? new Level(data.name, Number(data.height), editing.id)
+                    : l
+            )
+        );
+        setIsEditOpen(false);
+        setEditing(null);
+    }
+
+    function openDelete(id: number) {
+        setDeleteId(id);
+    }
+
+    async function confirmDelete() {
+        if (deleteId === null) return;
+        await LevelRepository.delete(deleteId);
+        setLevels(prev => prev.filter(l => l.id !== deleteId));
+        setDeleteId(null);
+    }
+
+    const editInitialData = editing
+        ? { name: editing.name, height: String(editing.height) }
+        : undefined;
+
+    return (
+        <SectionMain>
+            <Toaster />
+            <div className="menu flex justify-between items-center py-4">
+                <h1 className="font-semibold">Níveis</h1>
+                <EntityFormDialog title="Adicionar Nível" fields={fields} onSubmit={handleCreate} />
+            </div>
+            <Table data={levels} onEdit={openEdit} onDelete={openDelete} />
+            <EntityFormDialog
+                title="Editar Nível"
+                fields={fields}
+                onSubmit={handleEdit}
+                open={isEditOpen}
+                onOpenChange={(open) => {
+                    setIsEditOpen(open);
+                    if (!open) setEditing(null);
+                }}
+                initialData={editInitialData}
+                hideTrigger
+                submitLabel="Salvar"
+            />
+            {deleteId !== null && (
+                <Dialog open={true} onClose={() => setDeleteId(null)} className="relative z-50">
+                    <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+                    <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+                        <DialogPanel className="max-w-md w-full space-y-4 rounded border bg-white p-6">
+                            <DialogTitle className="text-lg font-bold">Confirmar exclusão</DialogTitle>
+                            <p>Deseja remover este nível?</p>
+                            <div className="mt-2 flex gap-3">
+                                <button type="button" onClick={() => setDeleteId(null)} className="px-4 py-2 rounded border">
+                                    Cancelar
+                                </button>
+                                <button type="button" onClick={() => void confirmDelete()} className="px-4 py-2 rounded bg-red-600 text-white">
+                                    Excluir
+                                </button>
+                            </div>
+                        </DialogPanel>
+                    </div>
+                </Dialog>
+            )}
+        </SectionMain>
     );
-    setIsEditOpen(false);
-    setEditing(null);
-  }
-
-  function openDelete(id: number) {
-    setDeleteId(id);
-  }
-
-  async function confirmDelete() {
-    if (deleteId === null) return;
-    await LevelRepository.delete(deleteId);
-    setLevels(prev => prev.filter(l => l.id !== deleteId));
-    setDeleteId(null);
-  }
-
-  const editInitialData = editing
-    ? { name: editing.name, height: String(editing.height) }
-    : undefined;
-
-  return (
-    <SectionMain>
-      <Toaster />
-      <div className="menu flex justify-between items-center py-4">
-        <h1 className="font-semibold">Níveis</h1>
-        <EntityFormDialog title="Adicionar Nível" fields={fields} onSubmit={handleCreate} />
-      </div>
-      <Table data={levels} onEdit={openEdit} onDelete={openDelete} />
-      <EntityFormDialog
-        title="Editar Nível"
-        fields={fields}
-        onSubmit={handleEdit}
-        open={isEditOpen}
-        onOpenChange={(open) => {
-          setIsEditOpen(open);
-          if (!open) setEditing(null);
-        }}
-        initialData={editInitialData}
-        hideTrigger
-        submitLabel="Salvar"
-      />
-      {deleteId !== null && (
-        <Dialog open={true} onClose={() => setDeleteId(null)} className="relative z-50">
-          <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-          <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
-            <DialogPanel className="max-w-md w-full space-y-4 rounded border bg-white p-6">
-              <DialogTitle className="text-lg font-bold">Confirmar exclusão</DialogTitle>
-              <p>Deseja remover este nível?</p>
-              <div className="mt-2 flex gap-3">
-                <button type="button" onClick={() => setDeleteId(null)} className="px-4 py-2 rounded border">
-                  Cancelar
-                </button>
-                <button type="button" onClick={() => void confirmDelete()} className="px-4 py-2 rounded bg-red-600 text-white">
-                  Excluir
-                </button>
-              </div>
-            </DialogPanel>
-          </div>
-        </Dialog>
-      )}
-    </SectionMain>
-  );
 }

--- a/src/pages/LevelsEditor/index.tsx
+++ b/src/pages/LevelsEditor/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
 import { Toaster, toast } from "sonner";
 import { Level } from "@/models/Level";
 import LevelRepository from "@/repositories/LevelRepository";
@@ -9,6 +10,9 @@ import { ENTITY_ADDED_SUCCESS } from "@/constants/messages";
 
 export default function LevelsEditor() {
   const [levels, setLevels] = useState<Level[]>([]);
+  const [editing, setEditing] = useState<Level | null>(null);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
 
   useEffect(() => {
     LevelRepository.getAll().then(setLevels);
@@ -26,6 +30,45 @@ export default function LevelsEditor() {
     toast.success(ENTITY_ADDED_SUCCESS);
   }
 
+  function openEdit(id: number) {
+    const level = levels.find(l => l.id === id);
+    if (!level) return;
+    setEditing(level);
+    setIsEditOpen(true);
+  }
+
+  async function handleEdit(data: Record<string, string>) {
+    if (!editing?.id) return;
+    await LevelRepository.update(editing.id, {
+      name: data.name,
+      height: Number(data.height),
+    });
+    setLevels(prev =>
+      prev.map(l =>
+        l.id === editing.id
+          ? new Level(data.name, Number(data.height), editing.id)
+          : l
+      )
+    );
+    setIsEditOpen(false);
+    setEditing(null);
+  }
+
+  function openDelete(id: number) {
+    setDeleteId(id);
+  }
+
+  async function confirmDelete() {
+    if (deleteId === null) return;
+    await LevelRepository.delete(deleteId);
+    setLevels(prev => prev.filter(l => l.id !== deleteId));
+    setDeleteId(null);
+  }
+
+  const editInitialData = editing
+    ? { name: editing.name, height: String(editing.height) }
+    : undefined;
+
   return (
     <SectionMain>
       <Toaster />
@@ -33,7 +76,39 @@ export default function LevelsEditor() {
         <h1 className="font-semibold">Níveis</h1>
         <EntityFormDialog title="Adicionar Nível" fields={fields} onSubmit={handleCreate} />
       </div>
-      <Table data={levels} />
+      <Table data={levels} onEdit={openEdit} onDelete={openDelete} />
+      <EntityFormDialog
+        title="Editar Nível"
+        fields={fields}
+        onSubmit={handleEdit}
+        open={isEditOpen}
+        onOpenChange={(open) => {
+          setIsEditOpen(open);
+          if (!open) setEditing(null);
+        }}
+        initialData={editInitialData}
+        hideTrigger
+        submitLabel="Salvar"
+      />
+      {deleteId !== null && (
+        <Dialog open={true} onClose={() => setDeleteId(null)} className="relative z-50">
+          <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+          <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+            <DialogPanel className="max-w-md w-full space-y-4 rounded border bg-white p-6">
+              <DialogTitle className="text-lg font-bold">Confirmar exclusão</DialogTitle>
+              <p>Deseja remover este nível?</p>
+              <div className="mt-2 flex gap-3">
+                <button type="button" onClick={() => setDeleteId(null)} className="px-4 py-2 rounded border">
+                  Cancelar
+                </button>
+                <button type="button" onClick={() => void confirmDelete()} className="px-4 py-2 rounded bg-red-600 text-white">
+                  Excluir
+                </button>
+              </div>
+            </DialogPanel>
+          </div>
+        </Dialog>
+      )}
     </SectionMain>
   );
 }

--- a/src/repositories/EquipamentRepository.ts
+++ b/src/repositories/EquipamentRepository.ts
@@ -4,17 +4,17 @@ import { BaseRepository } from './BaseRepository'
 import { toEquipament, fromEquipament, type EquipamentDTO } from '@/dto/equipament'
 
 class EquipamentRepository extends BaseRepository<Equipament, EquipamentDTO> {
-  constructor() {
-    super(db.equipaments, toEquipament, fromEquipament)
-  }
+    constructor() {
+        super(db.equipaments, toEquipament, fromEquipament)
+    }
 
-  update(id: number, changes: Partial<Equipament>) {
-    return super.update(id, changes)
-  }
+    update(id: number, changes: Partial<Equipament>) {
+        return super.update(id, changes)
+    }
 
-  delete(id: number) {
-    return super.delete(id)
-  }
+    delete(id: number) {
+        return super.delete(id)
+    }
 }
 
 export default new EquipamentRepository()

--- a/src/repositories/EquipamentRepository.ts
+++ b/src/repositories/EquipamentRepository.ts
@@ -7,6 +7,14 @@ class EquipamentRepository extends BaseRepository<Equipament, EquipamentDTO> {
   constructor() {
     super(db.equipaments, toEquipament, fromEquipament)
   }
+
+  update(id: number, changes: Partial<Equipament>) {
+    return super.update(id, changes)
+  }
+
+  delete(id: number) {
+    return super.delete(id)
+  }
 }
 
 export default new EquipamentRepository()

--- a/src/repositories/LevelRepository.ts
+++ b/src/repositories/LevelRepository.ts
@@ -4,17 +4,17 @@ import { BaseRepository } from './BaseRepository'
 import { toLevel, fromLevel, type LevelDTO } from '@/dto/level'
 
 class LevelRepository extends BaseRepository<Level, LevelDTO> {
-  constructor() {
-    super(db.levels, toLevel, fromLevel)
-  }
+    constructor() {
+        super(db.levels, toLevel, fromLevel)
+    }
 
-  update(id: number, changes: Partial<Level>) {
-    return super.update(id, changes)
-  }
+    update(id: number, changes: Partial<Level>) {
+        return super.update(id, changes)
+    }
 
-  delete(id: number) {
-    return super.delete(id)
-  }
+    delete(id: number) {
+        return super.delete(id)
+    }
 }
 
 export default new LevelRepository()

--- a/src/repositories/LevelRepository.ts
+++ b/src/repositories/LevelRepository.ts
@@ -7,6 +7,14 @@ class LevelRepository extends BaseRepository<Level, LevelDTO> {
   constructor() {
     super(db.levels, toLevel, fromLevel)
   }
+
+  update(id: number, changes: Partial<Level>) {
+    return super.update(id, changes)
+  }
+
+  delete(id: number) {
+    return super.delete(id)
+  }
 }
 
 export default new LevelRepository()


### PR DESCRIPTION
## Summary
- support optional edit/delete actions in generic Table component
- enable editing and removal of equipments and levels with dialogs
- expose update and delete methods in repositories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a7e2c0fe08321b34bd1463c80b93c