### PR TITLE
refactor: split entity pages

### DIFF
--- a/src/pages/Equipaments/CreatePage.tsx
+++ b/src/pages/Equipaments/CreatePage.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from "react-router-dom";
+import { Toaster, toast } from "sonner";
+
+import { Equipament } from "@/models/Equipament";
+import EquipamentRepository from "@/repositories/EquipamentRepository";
+import SectionMain from "@/components/SectionMain/SectionMain";
+import { ENTITY_ADDED_SUCCESS } from "@/constants/messages";
+
+import EquipamentForm from "./Form";
+
+export default function EquipamentCreatePage() {
+    const navigate = useNavigate();
+
+    async function handleSubmit(data: { name: string; abreviation: string; uhc: string }) {
+        const equip = new Equipament(data.name, data.abreviation, Number(data.uhc));
+        await EquipamentRepository.create(equip);
+        toast.success(ENTITY_ADDED_SUCCESS);
+        navigate("/equipaments");
+    }
+
+    return (
+        <SectionMain>
+            <Toaster />
+            <h1 className="font-semibold mb-4">Adicionar Peça</h1>
+            <EquipamentForm
+                initialData={{ name: "", abreviation: "", uhc: "" }}
+                onSubmit={handleSubmit}
+                onCancel={() => navigate("/equipaments")}
+            />
+        </SectionMain>
+    );
+}

--- a/src/pages/Equipaments/EditPage.tsx
+++ b/src/pages/Equipaments/EditPage.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Toaster, toast } from "sonner";
+
+import EquipamentRepository from "@/repositories/EquipamentRepository";
+import SectionMain from "@/components/SectionMain/SectionMain";
+import { ENTITY_UPDATED_SUCCESS } from "@/constants/messages";
+
+import EquipamentForm from "./Form";
+
+export default function EquipamentEditPage() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [initialData, setInitialData] = useState({ name: "", abreviation: "", uhc: "" });
+
+    useEffect(() => {
+        if (id) {
+            EquipamentRepository.getById(Number(id)).then(equip => {
+                if (equip) {
+                    setInitialData({ name: equip.name, abreviation: equip.abreviation, uhc: String(equip.uhc) });
+                }
+            });
+        }
+    }, [id]);
+
+    async function handleSubmit(data: { name: string; abreviation: string; uhc: string }) {
+        if (!id) return;
+        await EquipamentRepository.update(Number(id), {
+            name: data.name,
+            abreviation: data.abreviation,
+            uhc: Number(data.uhc),
+        });
+        toast.success(ENTITY_UPDATED_SUCCESS);
+        navigate("/equipaments");
+    }
+
+    return (
+        <SectionMain>
+            <Toaster />
+            <h1 className="font-semibold mb-4">Editar Peça</h1>
+            <EquipamentForm
+                initialData={initialData}
+                onSubmit={handleSubmit}
+                onCancel={() => navigate("/equipaments")}
+            />
+        </SectionMain>
+    );
+}

--- a/src/pages/Equipaments/Form.tsx
+++ b/src/pages/Equipaments/Form.tsx
@@ -1,26 +1,17 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { Toaster, toast } from "sonner";
 
-import { Equipament } from "@/models/Equipament";
-import EquipamentRepository from "@/repositories/EquipamentRepository";
-import SectionMain from "@/components/SectionMain/SectionMain";
-import { ENTITY_ADDED_SUCCESS, ENTITY_UPDATED_SUCCESS } from "@/constants/messages";
+interface EquipamentFormProps {
+    initialData: { name: string; abreviation: string; uhc: string };
+    onSubmit: (data: { name: string; abreviation: string; uhc: string }) => void | Promise<void>;
+    onCancel: () => void;
+}
 
-export default function EquipamentForm() {
-    const { id } = useParams();
-    const navigate = useNavigate();
-    const [data, setData] = useState({ name: "", abreviation: "", uhc: "" });
+export default function EquipamentForm({ initialData, onSubmit, onCancel }: EquipamentFormProps) {
+    const [data, setData] = useState(initialData);
 
     useEffect(() => {
-        if (id) {
-            EquipamentRepository.getById(Number(id)).then(equip => {
-                if (equip) {
-                    setData({ name: equip.name, abreviation: equip.abreviation, uhc: String(equip.uhc) });
-                }
-            });
-        }
-    }, [id]);
+        setData(initialData);
+    }, [initialData]);
 
     function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
         const { name, value } = e.target;
@@ -29,76 +20,60 @@ export default function EquipamentForm() {
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
-        if (id) {
-            await EquipamentRepository.update(Number(id), {
-                name: data.name,
-                abreviation: data.abreviation,
-                uhc: Number(data.uhc),
-            });
-            toast.success(ENTITY_UPDATED_SUCCESS);
-        } else {
-            const equip = new Equipament(data.name, data.abreviation, Number(data.uhc));
-            await EquipamentRepository.create(equip);
-            toast.success(ENTITY_ADDED_SUCCESS);
-        }
-        navigate("/equipaments");
+        await onSubmit(data);
     }
 
     return (
-        <SectionMain>
-            <Toaster />
-            <h1 className="font-semibold mb-4">{id ? "Editar Peça" : "Adicionar Peça"}</h1>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-md">
-                <div className="flex flex-col">
-                    <label htmlFor="name" className="text-sm font-medium">Nome</label>
-                    <input
-                        id="name"
-                        name="name"
-                        type="text"
-                        value={data.name}
-                        onChange={handleChange}
-                        className="rounded border p-2"
-                        required
-                    />
-                </div>
-                <div className="flex flex-col">
-                    <label htmlFor="abreviation" className="text-sm font-medium">Abreviação</label>
-                    <input
-                        id="abreviation"
-                        name="abreviation"
-                        type="text"
-                        value={data.abreviation}
-                        onChange={handleChange}
-                        className="rounded border p-2"
-                        required
-                    />
-                </div>
-                <div className="flex flex-col">
-                    <label htmlFor="uhc" className="text-sm font-medium">UHC</label>
-                    <input
-                        id="uhc"
-                        name="uhc"
-                        type="number"
-                        step="1"
-                        value={data.uhc}
-                        onChange={handleChange}
-                        className="rounded border p-2"
-                        required
-                    />
-                </div>
-                <div className="flex gap-3">
-                    <button
-                        type="button"
-                        onClick={() => navigate("/equipaments")}
-                        className="px-4 py-2 rounded border"
-                    >
-                        Cancelar
-                    </button>
-                    <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
-                        Salvar
-                    </button>
-                </div>
-            </form>
-        </SectionMain>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-md">
+            <div className="flex flex-col">
+                <label htmlFor="name" className="text-sm font-medium">Nome</label>
+                <input
+                    id="name"
+                    name="name"
+                    type="text"
+                    value={data.name}
+                    onChange={handleChange}
+                    className="rounded border p-2"
+                    required
+                />
+            </div>
+            <div className="flex flex-col">
+                <label htmlFor="abreviation" className="text-sm font-medium">Abreviação</label>
+                <input
+                    id="abreviation"
+                    name="abreviation"
+                    type="text"
+                    value={data.abreviation}
+                    onChange={handleChange}
+                    className="rounded border p-2"
+                    required
+                />
+            </div>
+            <div className="flex flex-col">
+                <label htmlFor="uhc" className="text-sm font-medium">UHC</label>
+                <input
+                    id="uhc"
+                    name="uhc"
+                    type="number"
+                    step="1"
+                    value={data.uhc}
+                    onChange={handleChange}
+                    className="rounded border p-2"
+                    required
+                />
+            </div>
+            <div className="flex gap-3">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="px-4 py-2 rounded border"
+                >
+                    Cancelar
+                </button>
+                <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
+                    Salvar
+                </button>
+            </div>
+        </form>
     );
 }

--- a/src/pages/Equipaments/ListPage.tsx
+++ b/src/pages/Equipaments/ListPage.tsx
@@ -8,7 +8,7 @@ import Table from "@/components/Table/Table";
 import SectionMain from "@/components/SectionMain/SectionMain";
 import { ENTITY_DELETED_SUCCESS } from "@/constants/messages";
 
-export default function EquipamentsList() {
+export default function EquipamentsListPage() {
     const [equipaments, setEquipaments] = useState<Equipament[]>([]);
     const navigate = useNavigate();
 

--- a/src/pages/Levels/CreatePage.tsx
+++ b/src/pages/Levels/CreatePage.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from "react-router-dom";
+import { Toaster, toast } from "sonner";
+
+import { Level } from "@/models/Level";
+import LevelRepository from "@/repositories/LevelRepository";
+import SectionMain from "@/components/SectionMain/SectionMain";
+import { ENTITY_ADDED_SUCCESS } from "@/constants/messages";
+
+import LevelForm from "./Form";
+
+export default function LevelCreatePage() {
+    const navigate = useNavigate();
+
+    async function handleSubmit(data: { name: string; height: string }) {
+        const level = new Level(data.name, Number(data.height));
+        await LevelRepository.create(level);
+        toast.success(ENTITY_ADDED_SUCCESS);
+        navigate("/levels");
+    }
+
+    return (
+        <SectionMain>
+            <Toaster />
+            <h1 className="font-semibold mb-4">Adicionar Nível</h1>
+            <LevelForm
+                initialData={{ name: "", height: "" }}
+                onSubmit={handleSubmit}
+                onCancel={() => navigate("/levels")}
+            />
+        </SectionMain>
+    );
+}

--- a/src/pages/Levels/EditPage.tsx
+++ b/src/pages/Levels/EditPage.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Toaster, toast } from "sonner";
+
+import LevelRepository from "@/repositories/LevelRepository";
+import SectionMain from "@/components/SectionMain/SectionMain";
+import { ENTITY_UPDATED_SUCCESS } from "@/constants/messages";
+
+import LevelForm from "./Form";
+
+export default function LevelEditPage() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [initialData, setInitialData] = useState({ name: "", height: "" });
+
+    useEffect(() => {
+        if (id) {
+            LevelRepository.getById(Number(id)).then(level => {
+                if (level) {
+                    setInitialData({ name: level.name, height: String(level.height) });
+                }
+            });
+        }
+    }, [id]);
+
+    async function handleSubmit(data: { name: string; height: string }) {
+        if (!id) return;
+        await LevelRepository.update(Number(id), {
+            name: data.name,
+            height: Number(data.height),
+        });
+        toast.success(ENTITY_UPDATED_SUCCESS);
+        navigate("/levels");
+    }
+
+    return (
+        <SectionMain>
+            <Toaster />
+            <h1 className="font-semibold mb-4">Editar Nível</h1>
+            <LevelForm
+                initialData={initialData}
+                onSubmit={handleSubmit}
+                onCancel={() => navigate("/levels")}
+            />
+        </SectionMain>
+    );
+}

--- a/src/pages/Levels/Form.tsx
+++ b/src/pages/Levels/Form.tsx
@@ -1,26 +1,17 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { Toaster, toast } from "sonner";
 
-import { Level } from "@/models/Level";
-import LevelRepository from "@/repositories/LevelRepository";
-import SectionMain from "@/components/SectionMain/SectionMain";
-import { ENTITY_ADDED_SUCCESS, ENTITY_UPDATED_SUCCESS } from "@/constants/messages";
+interface LevelFormProps {
+    initialData: { name: string; height: string };
+    onSubmit: (data: { name: string; height: string }) => void | Promise<void>;
+    onCancel: () => void;
+}
 
-export default function LevelForm() {
-    const { id } = useParams();
-    const navigate = useNavigate();
-    const [data, setData] = useState({ name: "", height: "" });
+export default function LevelForm({ initialData, onSubmit, onCancel }: LevelFormProps) {
+    const [data, setData] = useState(initialData);
 
     useEffect(() => {
-        if (id) {
-            LevelRepository.getById(Number(id)).then(level => {
-                if (level) {
-                    setData({ name: level.name, height: String(level.height) });
-                }
-            });
-        }
-    }, [id]);
+        setData(initialData);
+    }, [initialData]);
 
     function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
         const { name, value } = e.target;
@@ -29,63 +20,48 @@ export default function LevelForm() {
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
-        if (id) {
-            await LevelRepository.update(Number(id), {
-                name: data.name,
-                height: Number(data.height),
-            });
-            toast.success(ENTITY_UPDATED_SUCCESS);
-        } else {
-            const level = new Level(data.name, Number(data.height));
-            await LevelRepository.create(level);
-            toast.success(ENTITY_ADDED_SUCCESS);
-        }
-        navigate("/levels");
+        await onSubmit(data);
     }
 
     return (
-        <SectionMain>
-            <Toaster />
-            <h1 className="font-semibold mb-4">{id ? "Editar Nível" : "Adicionar Nível"}</h1>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-md">
-                <div className="flex flex-col">
-                    <label htmlFor="name" className="text-sm font-medium">Nome</label>
-                    <input
-                        id="name"
-                        name="name"
-                        type="text"
-                        value={data.name}
-                        onChange={handleChange}
-                        className="rounded border p-2"
-                        required
-                    />
-                </div>
-                <div className="flex flex-col">
-                    <label htmlFor="height" className="text-sm font-medium">Altura</label>
-                    <input
-                        id="height"
-                        name="height"
-                        type="number"
-                        step="any"
-                        value={data.height}
-                        onChange={handleChange}
-                        className="rounded border p-2"
-                        required
-                    />
-                </div>
-                <div className="flex gap-3">
-                    <button
-                        type="button"
-                        onClick={() => navigate("/levels")}
-                        className="px-4 py-2 rounded border"
-                    >
-                        Cancelar
-                    </button>
-                    <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
-                        Salvar
-                    </button>
-                </div>
-            </form>
-        </SectionMain>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-md">
+            <div className="flex flex-col">
+                <label htmlFor="name" className="text-sm font-medium">Nome</label>
+                <input
+                    id="name"
+                    name="name"
+                    type="text"
+                    value={data.name}
+                    onChange={handleChange}
+                    className="rounded border p-2"
+                    required
+                />
+            </div>
+            <div className="flex flex-col">
+                <label htmlFor="height" className="text-sm font-medium">Altura</label>
+                <input
+                    id="height"
+                    name="height"
+                    type="number"
+                    step="any"
+                    value={data.height}
+                    onChange={handleChange}
+                    className="rounded border p-2"
+                    required
+                />
+            </div>
+            <div className="flex gap-3">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="px-4 py-2 rounded border"
+                >
+                    Cancelar
+                </button>
+                <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
+                    Salvar
+                </button>
+            </div>
+        </form>
     );
 }

--- a/src/pages/Levels/ListPage.tsx
+++ b/src/pages/Levels/ListPage.tsx
@@ -8,7 +8,7 @@ import Table from "@/components/Table/Table";
 import SectionMain from "@/components/SectionMain/SectionMain";
 import { ENTITY_DELETED_SUCCESS } from "@/constants/messages";
 
-export default function LevelsList() {
+export default function LevelsListPage() {
     const [levels, setLevels] = useState<Level[]>([]);
     const navigate = useNavigate();
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,11 +3,13 @@ import { BrowserRouter, Routes, Route, Outlet } from 'react-router-dom';
 import Layout from '@/pages/Layout/Layout';
 import Home from '@/pages/Home';
 
-import EquipamentsList from '@/pages/Equipaments';
-import EquipamentForm from '@/pages/Equipaments/Form';
+import EquipamentsListPage from '@/pages/Equipaments/ListPage';
+import EquipamentCreatePage from '@/pages/Equipaments/CreatePage';
+import EquipamentEditPage from '@/pages/Equipaments/EditPage';
 import EquipamentSetsEditor from '@/pages/EquipamentSetsEditor';
-import LevelsList from '@/pages/Levels';
-import LevelForm from '@/pages/Levels/Form';
+import LevelsListPage from '@/pages/Levels/ListPage';
+import LevelCreatePage from '@/pages/Levels/CreatePage';
+import LevelEditPage from '@/pages/Levels/EditPage';
 import DownPipesEditor from '@/pages/DownPipesEditor';
 
 import NoPage from '@/pages/NoPage';
@@ -18,16 +20,16 @@ export function RoutesApp (){
             <Routes>
                 <Route path="/" element={<Layout />}>
                     <Route index element={<Home />} />
-                    <Route path="equipaments" element={<Outlet />}>
-                        <Route index element={<EquipamentsList />} />
-                        <Route path="new" element={<EquipamentForm />} />
-                        <Route path=":id" element={<EquipamentForm />} />
-                    </Route>
-                    <Route path="levels" element={<Outlet />}>
-                        <Route index element={<LevelsList />} />
-                        <Route path="new" element={<LevelForm />} />
-                        <Route path=":id" element={<LevelForm />} />
-                    </Route>
+                    <Route path="equipaments" element={<Outlet />}> 
+                        <Route index element={<EquipamentsListPage />} /> 
+                        <Route path="new" element={<EquipamentCreatePage />} /> 
+                        <Route path=":id" element={<EquipamentEditPage />} /> 
+                    </Route> 
+                    <Route path="levels" element={<Outlet />}> 
+                        <Route index element={<LevelsListPage />} /> 
+                        <Route path="new" element={<LevelCreatePage />} /> 
+                        <Route path=":id" element={<LevelEditPage />} /> 
+                    </Route> 
                     <Route path="conjuntos" element={<EquipamentSetsEditor />} />
                     <Route path="prumadas" element={<DownPipesEditor />} />
                     <Route path="*" element={<NoPage />} />


### PR DESCRIPTION
## Summary
- split level and equipament pages into list, create and edit pages
- add shared form components
- update routes to navigate between pages instead of modals

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb457aa58832195df7d50f912b249