### PR TITLE
Store equipament sets by item ids and hydrate for display

### DIFF
--- a/src/dto/equipamentSet.ts
+++ b/src/dto/equipamentSet.ts
@@ -1,27 +1,20 @@
 import { EquipamentSet } from '@/models/EquipamentSet';
-import { Equipament } from '@/models/Equipament';
-import { toEquipament, fromEquipament, type EquipamentDTO } from './equipament';
+
+export interface EquipamentSetItemDTO {
+  equipamentId?: number;
+  equipamentSetId?: number;
+}
 
 export interface EquipamentSetDTO {
   id?: number;
   name: string;
-  equipaments: Array<EquipamentDTO | EquipamentSetDTO>;
+  items: EquipamentSetItemDTO[];
 }
 
 export function toEquipamentSet(dto: EquipamentSetDTO): EquipamentSet {
-    const equipaments = dto.equipaments.map(item =>
-        'equipaments' in item
-            ? toEquipamentSet(item as EquipamentSetDTO)
-            : toEquipament(item as EquipamentDTO)
-    );
-    return new EquipamentSet(dto.name, equipaments, dto.id);
+    return new EquipamentSet(dto.name, dto.items, dto.id);
 }
 
 export function fromEquipamentSet(model: EquipamentSet): EquipamentSetDTO {
-    const equipaments = model.equipaments.map(item =>
-        item instanceof EquipamentSet
-            ? fromEquipamentSet(item)
-            : fromEquipament(item as Equipament)
-    );
-    return { id: model.id, name: model.name, equipaments };
+    return { id: model.id, name: model.name, items: model.items };
 }

--- a/src/models/Contribution.ts
+++ b/src/models/Contribution.ts
@@ -1,7 +1,7 @@
 import type { IElement, TableCell } from './InterfaceElement';
 import { Level } from './Level';
 import { Equipament } from './Equipament';
-import { EquipamentSet } from './EquipamentSet';
+import { HydratedEquipamentSet } from './EquipamentSet';
 
 export class Contribution {
     constructor(
@@ -15,12 +15,12 @@ export class Contribution {
 export class HydratedContribution implements IElement {
     constructor(
     public level: Level,
-    public equipament: Equipament | EquipamentSet,
+    public equipament: Equipament | HydratedEquipamentSet,
     public id?: number
     ) {}
 
     get totaluhc(): number {
-        return this.equipament instanceof EquipamentSet
+        return this.equipament instanceof HydratedEquipamentSet
             ? this.equipament.totaluhc
             : this.equipament.uhc;
     }

--- a/src/models/EquipamentSet.ts
+++ b/src/models/EquipamentSet.ts
@@ -1,16 +1,24 @@
 import { Equipament } from './Equipament';
 import type { IElement, TableCell } from './InterfaceElement';
 
-export class EquipamentSet implements IElement {
+export class EquipamentSet {
     constructor(
     public name: string,
-    public equipaments: Array<Equipament | EquipamentSet> = [],
+    public items: { equipamentId?: number; equipamentSetId?: number }[] = [],
+    public id?: number
+    ) {}
+}
+
+export class HydratedEquipamentSet implements IElement {
+    constructor(
+    public name: string,
+    public equipaments: Array<Equipament | HydratedEquipamentSet> = [],
     public id?: number
     ) {}
 
     get totaluhc(): number {
         return this.equipaments.reduce((sum, item) => {
-            if (item instanceof EquipamentSet) {
+            if (item instanceof HydratedEquipamentSet) {
                 return sum + item.totaluhc;
             }
             return sum + item.uhc;
@@ -25,4 +33,3 @@ export class EquipamentSet implements IElement {
         };
     }
 }
-

--- a/src/pages/EquipamentSetsEditor/index.tsx
+++ b/src/pages/EquipamentSetsEditor/index.tsx
@@ -1,15 +1,19 @@
 import { useEffect, useState } from "react";
 import { Toaster } from "sonner";
-import type { EquipamentSet } from "@/models/EquipamentSet";
+import type { HydratedEquipamentSet } from "@/models/EquipamentSet";
 import EquipamentSetRepository from "@/repositories/EquipamentSetRepository";
+import { hydrateEquipamentSet } from "@/utils/hydrateEquipamentSet";
 import Table from "@/components/Table/Table";
 import SectionMain from "@/components/SectionMain/SectionMain";
 
 export default function EquipamentSetsEditor() {
-    const [equipamentSets, setEquipamentSets] = useState<EquipamentSet[]>([]);
+    const [equipamentSets, setEquipamentSets] = useState<HydratedEquipamentSet[]>([]);
 	
     useEffect(() => {
-        EquipamentSetRepository.getAll().then(setEquipamentSets);
+        EquipamentSetRepository.getAll().then(async sets => {
+            const hydrated = await Promise.all(sets.map(hydrateEquipamentSet));
+            setEquipamentSets(hydrated);
+        });
     }, []);
 	
     return (

--- a/src/seeds/equipamentSets.ts
+++ b/src/seeds/equipamentSets.ts
@@ -1,16 +1,25 @@
 import type { AppDB } from '@/db/db';
 import { EquipamentSet } from '@/models/EquipamentSet';
-import { toEquipament } from '@/dto/equipament';
 import { fromEquipamentSet } from '@/dto/equipamentSet';
 
 export async function seedEquipamentSets(db: AppDB) {
-    const equipaments = (await db.equipaments.toArray()).map(toEquipament);
-    const e = (id: number) => equipaments.find(eq => eq.id === id)!;
-
     const sets: EquipamentSet[] = [
-        new EquipamentSet('WC', [e(1), e(2), e(4), e(5)], 1),
-        new EquipamentSet('Lavabo', [e(1), e(2), e(4)], 2),
-        new EquipamentSet('Área de Serviço e Cozinha', [e(7), e(10), e(9)], 3),
+        new EquipamentSet('WC', [
+            { equipamentId: 1 },
+            { equipamentId: 2 },
+            { equipamentId: 4 },
+            { equipamentId: 5 },
+        ], 1),
+        new EquipamentSet('Lavabo', [
+            { equipamentId: 1 },
+            { equipamentId: 2 },
+            { equipamentId: 4 },
+        ], 2),
+        new EquipamentSet('Área de Serviço e Cozinha', [
+            { equipamentId: 7 },
+            { equipamentId: 10 },
+            { equipamentId: 9 },
+        ], 3),
     ];
     await db.equipamentSets.bulkAdd(sets.map(fromEquipamentSet));
 }

--- a/src/tests/mappers.test.ts
+++ b/src/tests/mappers.test.ts
@@ -23,25 +23,15 @@ describe("DTO mappers", () => {
         expect(model).toMatchObject(dto);
     });
 
-    it("converts nested EquipamentSetDTO to EquipamentSet", () => {
+    it("converts EquipamentSetDTO to EquipamentSet", () => {
         const dto: EquipamentSetDTO = {
             id: 1,
             name: "Set",
-            equipaments: [
-        { id: 2, name: "E1", abreviation: "E1", uhc: 5 } as EquipamentDTO,
-        {
-            id: 3,
-            name: "Nested",
-            equipaments: [
-            { id: 4, name: "E2", abreviation: "E2", uhc: 7 } as EquipamentDTO,
-            ],
-        },
-            ],
+            items: [{ equipamentId: 2 }, { equipamentSetId: 3 }],
         };
         const model = toEquipamentSet(dto);
         expect(model).toBeInstanceOf(EquipamentSet);
-        expect(model.equipaments[0]).toBeInstanceOf(Equipament);
-        expect(model.equipaments[1]).toBeInstanceOf(EquipamentSet);
+        expect(model.items).toEqual(dto.items);
     });
 
     it("converts DownPipeDTO to DownPipe", () => {

--- a/src/tests/totaluhc.test.ts
+++ b/src/tests/totaluhc.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { HydratedContribution } from '@/models/Contribution'
 import { Level } from '@/models/Level'
 import { Equipament } from '@/models/Equipament'
-import { EquipamentSet } from '@/models/EquipamentSet'
+import { HydratedEquipamentSet } from '@/models/EquipamentSet'
 import { DownPipe } from '@/models/DownPipe'
 import { System } from '@/models/System'
 import { SystemType } from '@/models/enums/SystemType'
@@ -19,7 +19,7 @@ describe('totaluhc calculations', () => {
         const level = new Level('N1', 0)
         const e1 = new Equipament('E1', 'E1', 10)
         const e2 = new Equipament('E2', 'E2', 15)
-        const set = new EquipamentSet('Set', [e1, e2])
+        const set = new HydratedEquipamentSet('Set', [e1, e2])
         const contribution = new HydratedContribution(level, set)
         expect(contribution.totaluhc).toBe(25)
     })
@@ -27,8 +27,8 @@ describe('totaluhc calculations', () => {
     it('calculates totaluhc for nested EquipamentSet', () => {
         const e1 = new Equipament('E1', 'E1', 10)
         const e2 = new Equipament('E2', 'E2', 15)
-        const inner = new EquipamentSet('Inner', [e2])
-        const root = new EquipamentSet('Root', [e1, inner])
+        const inner = new HydratedEquipamentSet('Inner', [e2])
+        const root = new HydratedEquipamentSet('Root', [e1, inner])
         expect(root.totaluhc).toBe(25)
     })
 

--- a/src/utils/hydrateContribution.ts
+++ b/src/utils/hydrateContribution.ts
@@ -2,6 +2,7 @@ import { Contribution, HydratedContribution } from '@/models/Contribution';
 import LevelRepository from '@/repositories/LevelRepository';
 import EquipamentRepository from '@/repositories/EquipamentRepository';
 import EquipamentSetRepository from '@/repositories/EquipamentSetRepository';
+import { hydrateEquipamentSet } from './hydrateEquipamentSet';
 
 export async function hydrateContribution(
     contribution: Contribution
@@ -14,7 +15,12 @@ export async function hydrateContribution(
     const equipament =
     contribution.equipamentId !== undefined
         ? await EquipamentRepository.getById(contribution.equipamentId)
-        : await EquipamentSetRepository.getById(contribution.equipamentSetId!);
+        : await (async () => {
+            const set = await EquipamentSetRepository.getById(
+                contribution.equipamentSetId!
+            );
+            return set ? await hydrateEquipamentSet(set) : undefined;
+        })();
     if (!equipament) {
         throw new Error(
             `Equipament ${

--- a/src/utils/hydrateEquipamentSet.ts
+++ b/src/utils/hydrateEquipamentSet.ts
@@ -1,0 +1,21 @@
+import { EquipamentSet, HydratedEquipamentSet } from '@/models/EquipamentSet';
+import EquipamentRepository from '@/repositories/EquipamentRepository';
+import EquipamentSetRepository from '@/repositories/EquipamentSetRepository';
+
+export async function hydrateEquipamentSet(
+    set: EquipamentSet
+): Promise<HydratedEquipamentSet> {
+    const equipaments = await Promise.all(
+        set.items.map(async item => {
+            if (item.equipamentId !== undefined) {
+                const equip = await EquipamentRepository.getById(item.equipamentId);
+                if (!equip) throw new Error(`Equipament ${item.equipamentId} not found`);
+                return equip;
+            }
+            const child = await EquipamentSetRepository.getById(item.equipamentSetId!);
+            if (!child) throw new Error(`EquipamentSet ${item.equipamentSetId} not found`);
+            return hydrateEquipamentSet(child);
+        })
+    );
+    return new HydratedEquipamentSet(set.name, equipaments, set.id);
+}


### PR DESCRIPTION
## Summary
- model equipament sets with `items` referencing equipament or set IDs
- add `hydrateEquipamentSet` to build full objects
- hydrate equipament sets when listing and seeding data

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e691d1594832189c5758e274de71b