### PR TITLE
refactor downpipe relations

### DIFF
--- a/src/dto/downPipe.ts
+++ b/src/dto/downPipe.ts
@@ -1,23 +1,21 @@
 import { DownPipe } from '@/models/DownPipe';
-import { toSystem, fromSystem, type SystemDTO } from './system';
-import {
-    toHydratedContribution,
-    fromHydratedContribution,
-    type HydratedContributionDTO,
-} from './contribution';
 
 export interface DownPipeDTO {
   id?: number;
   numeration: string;
   diameter: number;
-  system: SystemDTO;
-  contributions: HydratedContributionDTO[];
+  systemId: number;
+  contributionIds: number[];
 }
 
 export function toDownPipe(dto: DownPipeDTO): DownPipe {
-    const system = toSystem(dto.system);
-    const contributions = dto.contributions.map(toHydratedContribution);
-    return new DownPipe(dto.numeration, dto.diameter, system, contributions, dto.id);
+    return new DownPipe(
+        dto.numeration,
+        dto.diameter,
+        dto.systemId,
+        dto.contributionIds,
+        dto.id
+    );
 }
 
 export function fromDownPipe(model: DownPipe): DownPipeDTO {
@@ -25,7 +23,8 @@ export function fromDownPipe(model: DownPipe): DownPipeDTO {
         id: model.id,
         numeration: model.numeration,
         diameter: model.diameter,
-        system: fromSystem(model.system),
-        contributions: model.contributions.map(fromHydratedContribution),
+        systemId: model.systemId,
+        contributionIds: model.contributionIds,
     };
 }
+

--- a/src/models/DownPipe.ts
+++ b/src/models/DownPipe.ts
@@ -4,19 +4,22 @@ import type { IElement, TableCell } from './InterfaceElement';
 
 export class DownPipe implements IElement {
     constructor(
-    public numeration: string,
-    public diameter: number,
-    public system: System,
-    public contributions: HydratedContribution[] = [],
-    public id?: number
+        public numeration: string,
+        public diameter: number,
+        public systemId: number,
+        public contributionIds: number[] = [],
+        public id?: number
     ) {}
+
+    system?: System;
+    contributions: HydratedContribution[] = [];
 
     get totaluhc(): number {
         return this.contributions.reduce((sum, c) => sum + c.totaluhc, 0);
     }
 
     get name(): string {
-        return `${this.system.systemAbreviation}${this.numeration}`;
+        return `${this.system?.systemAbreviation ?? ''}${this.numeration}`;
     }
 
     toTableRow(): Record<string, TableCell> {

--- a/src/pages/DownPipesEditor/index.tsx
+++ b/src/pages/DownPipesEditor/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Toaster } from 'sonner';
 import type { DownPipe } from '@/models/DownPipe';
-import DownPipeRepository from '@/repositories/DownPipeRepository';
+import DownPipeRepository, { hydrateDownPipe } from '@/repositories/DownPipeRepository';
 import Table from '@/components/Table/Table';
 import SectionMain from '@/components/SectionMain/SectionMain';
 
@@ -9,7 +9,9 @@ export default function DownPipesEditor() {
     const [downpipes, setDownpipes] = useState<DownPipe[]>([]);
 	
     useEffect(() => {
-        DownPipeRepository.getAll().then(setDownpipes);
+        DownPipeRepository.getAll()
+            .then(dps => Promise.all(dps.map(hydrateDownPipe)))
+            .then(setDownpipes);
     }, []);
 	
     return (

--- a/src/repositories/DownPipeRepository.ts
+++ b/src/repositories/DownPipeRepository.ts
@@ -1,12 +1,37 @@
-import { db } from '@/db/db'
-import type { DownPipe } from '@/models/DownPipe'
-import { BaseRepository } from './BaseRepository'
-import { toDownPipe, fromDownPipe, type DownPipeDTO } from '@/dto/downPipe'
+import { db } from '@/db/db';
+import type { DownPipe } from '@/models/DownPipe';
+import type { HydratedContribution } from '@/models/Contribution';
+import type { System } from '@/models/System';
+import { BaseRepository } from './BaseRepository';
+import { toDownPipe, fromDownPipe, type DownPipeDTO } from '@/dto/downPipe';
+import SystemRepository from './SystemRepository';
+import ContributionRepository from './ContributionRepository';
+
+export type HydratedDownPipe = DownPipe & {
+    system: System;
+    contributions: HydratedContribution[];
+};
+
+export async function hydrateDownPipe(pipe: DownPipe): Promise<HydratedDownPipe> {
+    const system = await SystemRepository.getById(pipe.systemId);
+    const contributions = await Promise.all(
+        pipe.contributionIds.map(id => ContributionRepository.getHydratedById(id))
+    );
+
+    return {
+        ...pipe,
+        system: system!,
+        contributions: contributions.filter(
+            (c): c is HydratedContribution => c !== undefined
+        ),
+    };
+}
 
 class DownPipeRepository extends BaseRepository<DownPipe, DownPipeDTO> {
     constructor() {
-        super(db.downpipes, toDownPipe, fromDownPipe)
+        super(db.downpipes, toDownPipe, fromDownPipe);
     }
 }
 
-export default new DownPipeRepository()
+export default new DownPipeRepository();
+

--- a/src/seeds/downPipes.ts
+++ b/src/seeds/downPipes.ts
@@ -1,83 +1,19 @@
 import type { AppDB } from '@/db/db';
 import { DownPipe } from '@/models/DownPipe';
-import { hydrateContribution } from '@/utils/hydrateContribution';
-import { toContribution } from '@/dto/contribution';
-import { toSystem } from '@/dto/system';
 import { fromDownPipe as fromDownPipeDTO } from '@/dto/downPipe';
 
 export async function seedDownPipes(db: AppDB) {
-    const systems = (await db.systems.toArray()).map(toSystem);
-    const contributions = (await db.contributions.toArray()).map(toContribution);
-    const s = (id: number) => systems.find(sys => sys.id === id)!;
-    const c = async (id: number) =>
-        hydrateContribution(contributions.find(con => con.id === id)!);
-
     const downpipes: DownPipe[] = [
-        new DownPipe('1', 100, s(1), [
-            await c(1),
-            await c(3),
-            await c(5),
-            await c(7),
-            await c(9),
-            await c(11),
-        ], 1),
-        new DownPipe('2', 100, s(1), [
-            await c(2),
-            await c(4),
-            await c(6),
-            await c(8),
-            await c(10),
-            await c(12),
-        ], 2),
-        new DownPipe('1', 100, s(2), [
-            await c(1),
-            await c(4),
-            await c(5),
-            await c(8),
-            await c(9),
-            await c(11),
-        ], 3),
-        new DownPipe('2', 100, s(2), [
-            await c(2),
-            await c(3),
-            await c(6),
-            await c(7),
-            await c(10),
-            await c(12),
-        ], 4),
-        new DownPipe('1', 100, s(3), [
-            await c(1),
-            await c(4),
-            await c(6),
-            await c(7),
-            await c(9),
-            await c(11),
-        ], 5),
-        new DownPipe('2', 100, s(3), [
-            await c(2),
-            await c(3),
-            await c(5),
-            await c(8),
-            await c(10),
-            await c(12),
-        ], 6),
-        new DownPipe('1', 100, s(4), [
-            await c(1),
-            await c(3),
-            await c(5),
-            await c(7),
-            await c(10),
-            await c(11),
-        ], 7),
-        new DownPipe('2', 100, s(4), [
-            await c(2),
-            await c(4),
-            await c(6),
-            await c(8),
-            await c(9),
-            await c(12),
-        ], 8),
+        new DownPipe('1', 100, 1, [1, 3, 5, 7, 9, 11], 1),
+        new DownPipe('2', 100, 1, [2, 4, 6, 8, 10, 12], 2),
+        new DownPipe('1', 100, 2, [1, 4, 5, 8, 9, 11], 3),
+        new DownPipe('2', 100, 2, [2, 3, 6, 7, 10, 12], 4),
+        new DownPipe('1', 100, 3, [1, 4, 6, 7, 9, 11], 5),
+        new DownPipe('2', 100, 3, [2, 3, 5, 8, 10, 12], 6),
+        new DownPipe('1', 100, 4, [1, 3, 5, 7, 10, 11], 7),
+        new DownPipe('2', 100, 4, [2, 4, 6, 8, 9, 12], 8),
     ];
 
     await db.downpipes.bulkAdd(downpipes.map(fromDownPipeDTO));
 }
+

--- a/src/tests/mappers.test.ts
+++ b/src/tests/mappers.test.ts
@@ -1,17 +1,8 @@
 import { describe, it, expect } from "vitest";
-import {
-    toContribution,
-    type ContributionDTO,
-    type HydratedContributionDTO,
-} from "@/dto/contribution";
+import { toContribution, type ContributionDTO } from "@/dto/contribution";
 import { toEquipamentSet, type EquipamentSetDTO } from "@/dto/equipamentSet";
 import { toDownPipe, type DownPipeDTO } from "@/dto/downPipe";
-import { type LevelDTO } from "@/dto/level";
-import { type EquipamentDTO } from "@/dto/equipament";
-import { type SystemDTO } from "@/dto/system";
-import { SystemType } from "@/models/enums/SystemType";
-import { Contribution, HydratedContribution } from "@/models/Contribution";
-import { Equipament } from "@/models/Equipament";
+import { Contribution } from "@/models/Contribution";
 import { EquipamentSet } from "@/models/EquipamentSet";
 import { DownPipe } from "@/models/DownPipe";
 
@@ -35,35 +26,16 @@ describe("DTO mappers", () => {
     });
 
     it("converts DownPipeDTO to DownPipe", () => {
-        const level: LevelDTO = { id: 1, name: "Nível 1", height: 0 };
-        const equip: EquipamentDTO = {
-            id: 1,
-            name: "E1",
-            abreviation: "E1",
-            uhc: 10,
-        };
-        const contributionDto: HydratedContributionDTO = {
-            id: 1,
-            level,
-            equipament: equip,
-        };
-        const system: SystemDTO = {
-            id: 1,
-            name: "Sistema",
-            systemAbreviation: "S",
-            systemType: SystemType.Hidraulico,
-        };
         const dto: DownPipeDTO = {
             id: 1,
             numeration: "1",
             diameter: 100,
-            system,
-            contributions: [contributionDto],
+            systemId: 1,
+            contributionIds: [1],
         };
         const model = toDownPipe(dto);
         expect(model).toBeInstanceOf(DownPipe);
-        expect(model.system.systemAbreviation).toBe("S");
-        expect(model.contributions[0]).toBeInstanceOf(HydratedContribution);
-        expect(model.contributions[0].equipament).toBeInstanceOf(Equipament);
+        expect(model.systemId).toBe(1);
+        expect(model.contributionIds).toEqual([1]);
     });
 });

--- a/src/tests/totaluhc.test.ts
+++ b/src/tests/totaluhc.test.ts
@@ -39,7 +39,9 @@ describe('totaluhc calculations', () => {
         const c1 = new HydratedContribution(level, e1)
         const c2 = new HydratedContribution(level, e2)
         const system = new System('Sistema', 'S', SystemType.Hidraulico)
-        const pipe = new DownPipe('1', 100, system, [c1, c2])
+        const pipe = new DownPipe('1', 100, 1, [1, 2])
+        pipe.system = system
+        pipe.contributions = [c1, c2]
         expect(pipe.totaluhc).toBe(30)
     })
 })


### PR DESCRIPTION
## Summary
- store references in downpipes using ids instead of hydrated objects
- add hydration logic in repository and UI
- update seeds and tests for new structure

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6b54e1d48321b11c3a126fbfdc07