### PR TITLE
Hydrate EquipamentSet items on load

### DIFF
--- a/src/pages/EquipamentSetsEditor/index.tsx
+++ b/src/pages/EquipamentSetsEditor/index.tsx
@@ -1,21 +1,17 @@
-import { useEffect, useState } from "react";
-import { Toaster } from "sonner";
-import type { HydratedEquipamentSet } from "@/models/EquipamentSet";
-import EquipamentSetRepository from "@/repositories/EquipamentSetRepository";
-import { hydrateEquipamentSet } from "@/utils/hydrateEquipamentSet";
-import Table from "@/components/Table/Table";
-import SectionMain from "@/components/SectionMain/SectionMain";
+import { useEffect, useState } from "react"
+import { Toaster } from "sonner"
+import type { HydratedEquipamentSet } from "@/models/EquipamentSet"
+import EquipamentSetRepository from "@/repositories/EquipamentSetRepository"
+import Table from "@/components/Table/Table"
+import SectionMain from "@/components/SectionMain/SectionMain"
 
 export default function EquipamentSetsEditor() {
-    const [equipamentSets, setEquipamentSets] = useState<HydratedEquipamentSet[]>([]);
-	
+    const [equipamentSets, setEquipamentSets] = useState<HydratedEquipamentSet[]>([])
+
     useEffect(() => {
-        EquipamentSetRepository.getAll().then(async sets => {
-            const hydrated = await Promise.all(sets.map(hydrateEquipamentSet));
-            setEquipamentSets(hydrated);
-        });
-    }, []);
-	
+        EquipamentSetRepository.getAll().then(setEquipamentSets)
+    }, [])
+
     return (
         <SectionMain>
             <Toaster />
@@ -24,3 +20,4 @@ export default function EquipamentSetsEditor() {
         </SectionMain>
     )
 }
+

--- a/src/repositories/EquipamentSetRepository.ts
+++ b/src/repositories/EquipamentSetRepository.ts
@@ -1,16 +1,46 @@
 import { db } from '@/db/db'
-import type { EquipamentSet } from '@/models/EquipamentSet'
+import { EquipamentSet, HydratedEquipamentSet } from '@/models/EquipamentSet'
 import { BaseRepository } from './BaseRepository'
 import {
     toEquipamentSet,
     fromEquipamentSet,
     type EquipamentSetDTO,
 } from '@/dto/equipamentSet'
+import { hydrateEquipamentSet } from '@/utils/hydrateEquipamentSet'
 
-class EquipamentSetRepository extends BaseRepository<EquipamentSet, EquipamentSetDTO> {
+class EquipamentSetRepository {
+    private base: BaseRepository<EquipamentSet, EquipamentSetDTO>
+
     constructor() {
-        super(db.equipamentSets, toEquipamentSet, fromEquipamentSet)
+        this.base = new BaseRepository(
+            db.equipamentSets,
+            toEquipamentSet,
+            fromEquipamentSet,
+        )
+    }
+
+    async getAll(): Promise<HydratedEquipamentSet[]> {
+        const sets = await this.base.getAll()
+        return Promise.all(sets.map(hydrateEquipamentSet))
+    }
+
+    async getById(id: number): Promise<HydratedEquipamentSet | undefined> {
+        const set = await this.base.getById(id)
+        return set ? await hydrateEquipamentSet(set) : undefined
+    }
+
+    create(data: EquipamentSet) {
+        return this.base.create(data)
+    }
+
+    update(id: number, changes: Partial<EquipamentSet>) {
+        return this.base.update(id, changes)
+    }
+
+    delete(id: number) {
+        return this.base.delete(id)
     }
 }
 
 export default new EquipamentSetRepository()
+

--- a/src/utils/hydrateContribution.ts
+++ b/src/utils/hydrateContribution.ts
@@ -1,33 +1,30 @@
-import { Contribution, HydratedContribution } from '@/models/Contribution';
-import LevelRepository from '@/repositories/LevelRepository';
-import EquipamentRepository from '@/repositories/EquipamentRepository';
-import EquipamentSetRepository from '@/repositories/EquipamentSetRepository';
-import { hydrateEquipamentSet } from './hydrateEquipamentSet';
+import { Contribution, HydratedContribution } from '@/models/Contribution'
+import LevelRepository from '@/repositories/LevelRepository'
+import EquipamentRepository from '@/repositories/EquipamentRepository'
+import EquipamentSetRepository from '@/repositories/EquipamentSetRepository'
 
 export async function hydrateContribution(
-    contribution: Contribution
+    contribution: Contribution,
 ): Promise<HydratedContribution> {
-    const level = await LevelRepository.getById(contribution.levelId);
+    const level = await LevelRepository.getById(contribution.levelId)
     if (!level) {
-        throw new Error(`Level ${contribution.levelId} not found`);
+        throw new Error(`Level ${contribution.levelId} not found`)
     }
 
     const equipament =
-    contribution.equipamentId !== undefined
-        ? await EquipamentRepository.getById(contribution.equipamentId)
-        : await (async () => {
-            const set = await EquipamentSetRepository.getById(
-                contribution.equipamentSetId!
-            );
-            return set ? await hydrateEquipamentSet(set) : undefined;
-        })();
+        contribution.equipamentId !== undefined
+            ? await EquipamentRepository.getById(contribution.equipamentId)
+            : await EquipamentSetRepository.getById(
+                contribution.equipamentSetId!,
+            )
     if (!equipament) {
         throw new Error(
             `Equipament ${
                 contribution.equipamentId ?? contribution.equipamentSetId
-            } not found`
-        );
+            } not found`,
+        )
     }
 
-    return new HydratedContribution(level, equipament, contribution.id);
+    return new HydratedContribution(level, equipament, contribution.id)
 }
+


### PR DESCRIPTION
## Summary
- hydrate equipment set items when retrieving from repository
- streamline contribution hydration with hydrated sets
- simplify EquipamentSetsEditor to use hydrated data

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e72ecd8e88321ac6d811417b23ce5