### PR TITLE
Support contribution quantities and show set item details

### DIFF
--- a/src/dto/contribution.ts
+++ b/src/dto/contribution.ts
@@ -1,6 +1,7 @@
 export interface ContributionDTO {
   id?: number;
   levelId: number;
+  quantity?: number;
   equipamentId?: number;
   equipamentSetId?: number;
 }
@@ -20,6 +21,7 @@ import {
 export function toContribution(dto: ContributionDTO): Contribution {
     return new Contribution(
         dto.levelId,
+        dto.quantity ?? 1,
         dto.equipamentId,
         dto.equipamentSetId,
         dto.id,
@@ -30,6 +32,7 @@ export function fromContribution(model: Contribution): ContributionDTO {
     return {
         id: model.id,
         levelId: model.levelId,
+        quantity: model.quantity,
         equipamentId: model.equipamentId,
         equipamentSetId: model.equipamentSetId,
     };
@@ -38,6 +41,7 @@ export function fromContribution(model: Contribution): ContributionDTO {
 export interface HydratedContributionDTO {
   id: number;
   level: LevelDTO;
+  quantity: number;
   equipament: EquipamentDTO | EquipamentSetDTO;
 }
 
@@ -49,7 +53,7 @@ export function toHydratedContribution(
     'items' in dto.equipament
         ? toEquipamentSet(dto.equipament as EquipamentSetDTO)
         : toEquipament(dto.equipament as EquipamentDTO);
-    return new HydratedContribution(level, equipament as Equipament | HydratedEquipamentSet, dto.id);
+    return new HydratedContribution(level, equipament as Equipament | HydratedEquipamentSet, dto.quantity, dto.id);
 }
 
 export function fromHydratedContribution(
@@ -71,6 +75,7 @@ export function fromHydratedContribution(
     return {
         id: model.id!,
         level: fromLevel(model.level),
+        quantity: model.quantity,
         equipament,
     };
 }

--- a/src/models/Contribution.ts
+++ b/src/models/Contribution.ts
@@ -5,24 +5,28 @@ import { HydratedEquipamentSet } from './EquipamentSet';
 
 export class Contribution {
     constructor(
-    public levelId: number,
-    public equipamentId?: number,
-    public equipamentSetId?: number,
-    public id?: number
+        public levelId: number,
+        public quantity: number = 1,
+        public equipamentId?: number,
+        public equipamentSetId?: number,
+        public id?: number,
     ) {}
 }
 
 export class HydratedContribution implements IElement {
     constructor(
-    public level: Level,
-    public equipament: Equipament | HydratedEquipamentSet,
-    public id?: number
+        public level: Level,
+        public equipament: Equipament | HydratedEquipamentSet,
+        public quantity: number = 1,
+        public id?: number,
     ) {}
 
     get totaluhc(): number {
-        return this.equipament instanceof HydratedEquipamentSet
-            ? this.equipament.totaluhc
-            : this.equipament.uhc;
+        const uhc =
+            this.equipament instanceof HydratedEquipamentSet
+                ? this.equipament.totaluhc
+                : this.equipament.uhc;
+        return uhc * this.quantity;
     }
 
     toTableRow(): Record<string, TableCell> {
@@ -30,6 +34,7 @@ export class HydratedContribution implements IElement {
             ID: { value: this.id ?? '', align: 'center' },
             Nível: { value: this.level.name },
             Equipamento: { value: this.equipament.name },
+            Quantidade: { value: this.quantity, align: 'center' },
             UHC: { value: this.totaluhc, align: 'center' },
         };
     }

--- a/src/models/EquipamentSet.ts
+++ b/src/models/EquipamentSet.ts
@@ -33,9 +33,14 @@ export class HydratedEquipamentSet implements IElement {
     }
 
     toTableRow(): Record<string, TableCell> {
+        const names = this.items.map(i => i.equipament.name).join(', ');
+        const quantities = this.items.map(i => i.quantity).join(', ');
+
         return {
             ID: { value: this.id ?? '', align: 'center' },
             Nome: { value: this.name },
+            Equipamento: { value: names },
+            Quantidade: { value: quantities, align: 'center' },
             'UHC Total': { value: this.totaluhc, align: 'center' },
         };
     }

--- a/src/repositories/ContributionRepository.ts
+++ b/src/repositories/ContributionRepository.ts
@@ -20,7 +20,13 @@ class ContributionRepository {
     async create(data: Contribution): Promise<Contribution> {
         const dto: ContributionDTO = fromContribution(data);
         const id = await this.table.add(dto);
-        return new Contribution(data.levelId, data.equipamentId, data.equipamentSetId, id);
+        return new Contribution(
+            data.levelId,
+            data.quantity,
+            data.equipamentId,
+            data.equipamentSetId,
+            id,
+        );
     }
 
     async update(id: number, changes: Partial<Contribution>): Promise<number> {

--- a/src/seeds/contributions.ts
+++ b/src/seeds/contributions.ts
@@ -4,18 +4,18 @@ import { fromContribution } from '@/dto/contribution';
 
 export async function seedContributions(db: AppDB) {
     const contributions: Contribution[] = [
-        new Contribution(1, 1, undefined, 1),
-        new Contribution(1, undefined, 1, 2),
-        new Contribution(2, 2, undefined, 3),
-        new Contribution(2, undefined, 2, 4),
-        new Contribution(3, 3, undefined, 5),
-        new Contribution(3, undefined, 3, 6),
-        new Contribution(4, 4, undefined, 7),
-        new Contribution(4, 5, undefined, 8),
-        new Contribution(5, 7, undefined, 9),
-        new Contribution(5, 9, undefined, 10),
-        new Contribution(6, 10, undefined, 11),
-        new Contribution(6, 8, undefined, 12),
+        new Contribution(1, 1, 1, undefined, 1),
+        new Contribution(1, 1, undefined, 1, 2),
+        new Contribution(2, 1, 2, undefined, 3),
+        new Contribution(2, 1, undefined, 2, 4),
+        new Contribution(3, 1, 3, undefined, 5),
+        new Contribution(3, 1, undefined, 3, 6),
+        new Contribution(4, 1, 4, undefined, 7),
+        new Contribution(4, 1, 5, undefined, 8),
+        new Contribution(5, 1, 7, undefined, 9),
+        new Contribution(5, 1, 9, undefined, 10),
+        new Contribution(6, 1, 10, undefined, 11),
+        new Contribution(6, 1, 8, undefined, 12),
     ];
 
     await db.contributions.bulkAdd(contributions.map(fromContribution));

--- a/src/tests/totaluhc.test.ts
+++ b/src/tests/totaluhc.test.ts
@@ -27,6 +27,21 @@ describe('totaluhc calculations', () => {
         expect(contribution.totaluhc).toBe(25)
     })
 
+    it('multiplies uhc by quantity inside EquipamentSet', () => {
+        const e1 = new Equipament('E1', 'E1', 10)
+        const set = new HydratedEquipamentSet('Set', [
+            { equipament: e1, quantity: 3 },
+        ])
+        expect(set.totaluhc).toBe(30)
+    })
+
+    it('multiplies contribution totaluhc by quantity', () => {
+        const level = new Level('N1', 0)
+        const e1 = new Equipament('E1', 'E1', 10)
+        const contribution = new HydratedContribution(level, e1, 3)
+        expect(contribution.totaluhc).toBe(30)
+    })
+
     it('calculates totaluhc for nested EquipamentSet', () => {
         const e1 = new Equipament('E1', 'E1', 10)
         const e2 = new Equipament('E2', 'E2', 15)

--- a/src/utils/hydrateContribution.ts
+++ b/src/utils/hydrateContribution.ts
@@ -25,6 +25,6 @@ export async function hydrateContribution(
         )
     }
 
-    return new HydratedContribution(level, equipament, contribution.id)
+    return new HydratedContribution(level, equipament, contribution.quantity, contribution.id)
 }
 


### PR DESCRIPTION
## Summary
- factor contribution quantity into total UHC calculations
- display equipment names and quantities in EquipamentSet listings
- extend contribution DTOs and repository to persist quantity
- add tests covering quantity-based calculations

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689e767ce7d48321847a3edd2910b77c